### PR TITLE
Setup on Ubuntu 20.04 should install pip3

### DIFF
--- a/scripts/ubuntu2004/install_reqs.sh
+++ b/scripts/ubuntu2004/install_reqs.sh
@@ -20,7 +20,7 @@ apt-get update
 
 apt-get install -y build-essential software-properties-common wget libedit-dev libz-dev \
   python-yaml python3-pip pkg-config libssl-dev libcurl4-openssl-dev curl \
-  uuid-dev git libffi-dev \
+  uuid-dev git libffi-dev libmagic-dev \
   doxygen doxygen-doc doxygen-latex doxygen-gui graphviz \
   libgflags-dev libncurses-dev \
   awscli openjdk-8-jdk libyaml-dev

--- a/scripts/ubuntu2004/install_reqs.sh
+++ b/scripts/ubuntu2004/install_reqs.sh
@@ -19,7 +19,7 @@ add-apt-repository -y ppa:deadsnakes/ppa
 apt-get update
 
 apt-get install -y build-essential software-properties-common wget libedit-dev libz-dev \
-  python-yaml pkg-config libssl-dev libcurl4-openssl-dev curl \
+  python-yaml python3-pip pkg-config libssl-dev libcurl4-openssl-dev curl \
   uuid-dev git libffi-dev \
   doxygen doxygen-doc doxygen-latex doxygen-gui graphviz \
   libgflags-dev libncurses-dev \


### PR DESCRIPTION
If pip3 isn't installed, we should install it.