### PR TITLE
[BUILD] Reduce compiler warnings

### DIFF
--- a/tuplex/CMakeLists.txt
+++ b/tuplex/CMakeLists.txt
@@ -139,6 +139,14 @@ if(GENERATE_PDFS)
 else()
     message(STATUS "PDF generation for ASTs and logical plans disabled. Enable by setting -DGENERATE_PDFS=ON.")
 endif()
+
+# suppress "#warning" directive otuput
+option(SHOW_EXPLICIT_WARNINGS "Show the output of #warning directives in the code (lots of output)" OFF)
+if(SHOW_EXPLICIT_WARNINGS)
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-cpp")
+endif()
+
 ###########################################################################
 # (1) supported compilers and fixes
 ###########################################################################

--- a/tuplex/codegen/include/Pipe.h
+++ b/tuplex/codegen/include/Pipe.h
@@ -33,7 +33,7 @@ public:
      * @param file_input
      * @return return value of the process
      */
-    int pipe(const std::string& file_input = "");
+    int pipe(const std::string& file_input = "", const std::string& tmpdir = "/tmp");
 
     /*!
      * return value of the command executed

--- a/tuplex/codegen/src/Pipe.cc
+++ b/tuplex/codegen/src/Pipe.cc
@@ -43,7 +43,7 @@ int Pipe::pipe(const std::string& file_input, const std::string& tmpdir) {
 
             char* tmpname = new char[tmpdir.size() + 13];
             snprintf(tmpname, tmpdir.size() + 13, "%s/pipe-XXXXXX", tmpdir.c_str());
-            int fd = mkstemps(tmpname, 3);
+            int fd = mkstemp(tmpname);
             if (fd < 0) {
                 Logger::instance().logger("pipe").error(std::string("error while creating temporary file"));
                 _retval = 1;

--- a/tuplex/codegen/src/Pipe.cc
+++ b/tuplex/codegen/src/Pipe.cc
@@ -16,7 +16,7 @@
 #include <fstream>
 #include <cstdlib>
 
-int Pipe::pipe(const std::string& file_input) {
+int Pipe::pipe(const std::string& file_input, const std::string& tmpdir) {
 
     try {
 
@@ -41,11 +41,22 @@ int Pipe::pipe(const std::string& file_input) {
             // @TODO: global temp dir should be used...
             // needs to be a configurable option...
 
-            char tmpname[22];
-            sprintf(tmpname, "/tmp/tuplex-XXXXXX.py");
+            char* tmpname = new char[tmpdir.size() + 13];
+            snprintf(tmpname, tmpdir.size() + 13, "%s/pipe-XXXXXX", tmpdir.c_str());
             int fd = mkstemps(tmpname, 3);
+            if (fd < 0) {
+                Logger::instance().logger("pipe").error(std::string("error while creating temporary file"));
+                _retval = 1;
+                return retval();
+            }
 
             std::FILE* tmp = fdopen(fd, "w");
+            if (!tmp) {
+                Logger::instance().logger("pipe").error(std::string("error opening temporary file"));
+                _retval = 1;
+                return retval();
+            }
+
             fwrite(file_input.c_str(), file_input.size(), 1, tmp);
             fclose(tmp);
             cmd += " " + std::string(tmpname);

--- a/tuplex/codegen/src/Pipe.cc
+++ b/tuplex/codegen/src/Pipe.cc
@@ -41,13 +41,14 @@ int Pipe::pipe(const std::string& file_input) {
             // @TODO: global temp dir should be used...
             // needs to be a configurable option...
 
-            // deprecated
-            // @TODO
-            std::string tmppath = std::tmpnam(nullptr);
-            std::ofstream ofs(tmppath + ".py");
-            ofs<<file_input;
-            ofs.close();
-            cmd += " " + tmppath + ".py";
+            char tmpname[22];
+            sprintf(tmpname, "/tmp/tuplex-XXXXXX.py");
+            int fd = mkstemps(tmpname, 3);
+
+            std::FILE* tmp = fdopen(fd, "w");
+            fwrite(file_input.c_str(), file_input.size(), 1, tmp);
+            fclose(tmp);
+            cmd += " " + std::string(tmpname);
         }
 
         child c(cmd, std_err > pipe_stderr, std_out > pipe_stdout);

--- a/tuplex/utils/include/Utils.h
+++ b/tuplex/utils/include/Utils.h
@@ -360,13 +360,6 @@ namespace tuplex {
             return "";
     }
 
-    /*!
-     * temporary filename
-     * @return
-     */
-    extern std::string temporaryPathName();
-
-
     // hashing functions
     // based on https://stackoverflow.com/questions/34597260/stdhash-value-on-char-value-and-not-on-memory-address
     // and http://www.isthe.com/chongo/tech/comp/fnv/index.html

--- a/tuplex/utils/src/Utils.cc
+++ b/tuplex/utils/src/Utils.cc
@@ -199,9 +199,4 @@ namespace tuplex {
             os << "|" << std::endl;
         }
     }
-
-    std::string temporaryPathName() {
-        // reimplement safer...
-        return std::tmpnam(nullptr);
-    }
 }


### PR DESCRIPTION
Removes many compiler warnings to make it easier to spot important warnings and errors in the output.

1. Replaces deprecated `tmpnam(3)` where used (one piece of dead code, one actual implementation in Pipe.cc).
2. Disables `#warning` directive output (which gets repeated every time a header is included) by default. Use `SHOW_EXPLICIT_WARNINGS` to turn it back on. Most of this relates to unimplemented features, so doesn't need to be shown by default.