### PR TITLE
[FIX] Update Orc Tests and Cmake

### DIFF
--- a/tuplex/io/CMakeLists.txt
+++ b/tuplex/io/CMakeLists.txt
@@ -31,7 +31,25 @@ if(BREW_FOUND)
         # Snappy
         EXECUTE_PROCESS(COMMAND brew list snappy OUTPUT_VARIABLE BREW_SNAPPY_LIST ERROR_VARIABLE BREW_SNAPPY_NOTFOUND OUTPUT_STRIP_TRAILING_WHITESPACE)
         if(BREW_SNAPPY_NOTFOUND)
-            set(SNAPPY_LIBRARIES "${EXTERNAL_INSTALL_LOCATION}/lib/libsnappy.a")
+            set(SNAPPY_VERSION "1.1.7")
+            set(SNAPPY_HOME "${EXTERNAL_INSTALL_LOCATION}")
+            set(SNAPPY_INCLUDE_DIR "${SNAPPY_HOME}/include")
+            set(SNAPPY_STATIC_LIB "${SNAPPY_HOME}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}snappy${CMAKE_STATIC_LIBRARY_SUFFIX}")
+            set(SNAPPY_CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${SNAPPY_HOME}
+                    -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_LIBDIR=lib -DSNAPPY_BUILD_TESTS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON)
+            ExternalProject_Add (snappy_ep
+                    URL "https://github.com/google/snappy/archive/${SNAPPY_VERSION}.tar.gz"
+                    CMAKE_ARGS ${SNAPPY_CMAKE_ARGS}
+                    BUILD_BYPRODUCTS "${SNAPPY_STATIC_LIB}")
+
+            set(SNAPPY_LIBRARIES ${SNAPPY_STATIC_LIB})
+
+            add_library(snappy INTERFACE)
+            target_link_libraries(snappy INTERFACE ${SNAPPY_STATIC_LIB})
+            target_include_directories(snappy SYSTEM INTERFACE ${SNAPPY_INCLUDE_DIR})
+
+            add_dependencies(snappy snappy_ep)
+            install(FILES "${SNAPPY_STATIC_LIB}" DESTINATION "lib")
         else()
             EXECUTE_PROCESS(COMMAND brew --prefix snappy OUTPUT_VARIABLE BREW_SNAPPY_DIR OUTPUT_STRIP_TRAILING_WHITESPACE)
             set(ENV{SNAPPY_HOME} ${BREW_SNAPPY_DIR})
@@ -143,10 +161,6 @@ if(BREW_FOUND)
 endif()
 
 # set to third-party build
-if(NOT SNAPPY_LIBRARIES)
-    set(SNAPPY_HOME "")
-    set(SNAPPY_LIBRARIES ${EXTERNAL_INSTALL_LOCATION}/lib/libsnappy.a)
-endif()
 
 if(NOT LZ4_LIBRARIES)
     set(LZ4_HOME "")
@@ -174,7 +188,6 @@ ExternalProject_Add(orc
         BUILD_BYPRODUCTS
         ${EXTERNAL_INSTALL_LOCATION}/lib/liborc.a
         ${LZ4_LIBRARIES}
-        ${SNAPPY_LIBRARIES}
         ${ZLIB_LIBRARIES}
         ${ZSTD_LIBRARIES}
         )

--- a/tuplex/test/io/OrcWriteTest.cc
+++ b/tuplex/test/io/OrcWriteTest.cc
@@ -17,30 +17,44 @@
 
 class OrcWriteTest : public PyTest {};
 
-void writeRowInput(const std::vector<tuplex::Row> &rows, const std::vector<std::string>& columnNames = {});
-void writeCSVInput(const std::string &path);
+void writeDataSet(tuplex::DataSet &ds);
 
 TEST_F(OrcWriteTest, WriteZillow) {
     using namespace tuplex;
     auto files = VirtualFileSystem::globAll("../resources/pipelines/zillow/*.csv");
+
+    auto opts = ContextOptions::defaults();
+    Context c(opts);
+
     for (const auto& file : files) {
-        writeCSVInput(file.toPath());
+        auto &ds = c.csv(file.toPath());
+        writeDataSet(ds);
     }
 }
 
 TEST_F(OrcWriteTest, WriteGtrace) {
     using namespace tuplex;
     auto files = VirtualFileSystem::globAll("../resources/pipelines/gtrace/*.csv");
+
+    auto opts = ContextOptions::defaults();
+    Context c(opts);
+
     for (const auto& file : files) {
-        writeCSVInput(file.toPath());
+        auto &ds = c.csv(file.toPath());
+        writeDataSet(ds);
     }
 }
 
 TEST_F(OrcWriteTest, WriteWeblogs) {
     using namespace tuplex;
     auto files = VirtualFileSystem::globAll("../resources/pipelines/weblogs/*.csv");
+
+    auto opts = ContextOptions::defaults();
+    Context c(opts);
+
     for (const auto& file : files) {
-        writeCSVInput(file.toPath());
+        auto &ds = c.csv(file.toPath());
+        writeDataSet(ds);
     }
 }
 
@@ -50,7 +64,11 @@ TEST_F(OrcWriteTest, WriteComplex) {
             Row(Tuple(List(1, 2, 3))),
             Row(Tuple(List(5)))
     };
-    writeRowInput(rows);
+
+    auto opts = microTestOptions();
+    Context c(opts);
+    auto &ds = c.parallelize(rows);
+    writeDataSet(ds);
 }
 
 TEST_F(OrcWriteTest, WriteTuples) {
@@ -60,7 +78,11 @@ TEST_F(OrcWriteTest, WriteTuples) {
             Row(Tuple(1, Tuple(2, 3)), Tuple(Tuple(4, 5), 6, 7, Tuple(8,9))),
             Row(Tuple(1, Tuple(2, 3)), Tuple(Tuple(4, 5), 6, 7, Tuple(8,9)))
     };
-    writeRowInput(rows);
+
+    auto opts = microTestOptions();
+    Context c(opts);
+    auto &ds = c.parallelize(rows);
+    writeDataSet(ds);
 }
 
 TEST_F(OrcWriteTest, WriteDict) {
@@ -79,7 +101,11 @@ TEST_F(OrcWriteTest, WriteDict) {
                 Field::from_str_data(bool_to_str,
                                      python::Type::makeDictionaryType(python::Type::BOOLEAN, python::Type::STRING)))
     };
-    writeRowInput(rows);
+
+    auto opts = microTestOptions();
+    Context c(opts);
+    auto &ds = c.parallelize(rows);
+    writeDataSet(ds);
 }
 
 TEST_F(OrcWriteTest, WriteColumns) {
@@ -89,7 +115,12 @@ TEST_F(OrcWriteTest, WriteColumns) {
             Row(2, true),
             Row(3, true)
     };
-    writeRowInput(rows, {"int", "bool"});
+
+    auto opts = microTestOptions();
+    Context c(opts);
+    std::vector<std::string> columnNames({"int", "bool"});
+    auto &ds = c.parallelize(rows, columnNames);
+    writeDataSet(ds);
 }
 
 TEST_F(OrcWriteTest, WriteList) {
@@ -100,7 +131,10 @@ TEST_F(OrcWriteTest, WriteList) {
             Row(List(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1), List(1.1,1.1,1.1,1.1,1.1,1.1,1.1), List("a","a","a","a","a","a","a","a","a","a","a","a","a","a","a"), List(false,false,false,false,false,false,false,false,false,false,false)),
             Row(List(6), List(4.4, 5.5, 6.6), List("f"), List(false))
     };
-    writeRowInput(rows);
+    auto opts = microTestOptions();
+    Context c(opts);
+    auto &ds = c.parallelize(rows);
+    writeDataSet(ds);
 }
 
 TEST_F(OrcWriteTest, WriteOptions) {
@@ -111,7 +145,10 @@ TEST_F(OrcWriteTest, WriteOptions) {
             Row(option<int>(2), option<double>(2.2), option<std::string>("bb"), option<bool>(true)),
             Row(option<int>::none, option<double>::none, option<std::string>::none, option<bool>::none)
     };
-    writeRowInput(rows);
+    auto opts = microTestOptions();
+    Context c(opts);
+    auto &ds = c.parallelize(rows);
+    writeDataSet(ds);
 }
 
 TEST_F(OrcWriteTest, WriteI64) {
@@ -121,7 +158,10 @@ TEST_F(OrcWriteTest, WriteI64) {
             Row(4, 5, 6),
             Row(7, 8, 9)
     };
-    writeRowInput(rows);
+    auto opts = microTestOptions();
+    Context c(opts);
+    auto &ds = c.parallelize(rows);
+    writeDataSet(ds);
 }
 
 TEST_F(OrcWriteTest, WriteF64) {
@@ -131,7 +171,10 @@ TEST_F(OrcWriteTest, WriteF64) {
             Row(4.4, 5.5, 6.6),
             Row(7.7777, 8.8888, 9.9999)
     };
-    writeRowInput(rows);
+    auto opts = microTestOptions();
+    Context c(opts);
+    auto &ds = c.parallelize(rows);
+    writeDataSet(ds);
 }
 
 TEST_F(OrcWriteTest, WriteBoolean) {
@@ -141,7 +184,10 @@ TEST_F(OrcWriteTest, WriteBoolean) {
             Row(false, false, false),
             Row(true, false, true)
     };
-    writeRowInput(rows);
+    auto opts = microTestOptions();
+    Context c(opts);
+    auto &ds = c.parallelize(rows);
+    writeDataSet(ds);
 }
 
 TEST_F(OrcWriteTest, WriteString) {
@@ -152,7 +198,116 @@ TEST_F(OrcWriteTest, WriteString) {
             Row("aaa", "b", "cc"),
             Row("", "", "")
     };
-    writeRowInput(rows);
+    auto opts = microTestOptions();
+    Context c(opts);
+    auto &ds = c.parallelize(rows);
+    writeDataSet(ds);
+}
+
+tuplex::Field keyToField(cJSON *entry, const python::Type& type);
+tuplex::Field valueToField(cJSON *entry, const python::Type& type);
+std::string fieldToORCString(const tuplex::Field &field, const python::Type& type);
+std::string rowToORCString(const tuplex::Row &row, const std::vector<std::string>& columnNames = {});
+
+void writeDataSet(tuplex::DataSet &ds) {
+    using namespace tuplex;
+
+    std::string folderName(::testing::UnitTest::GetInstance()->current_test_info()->name());
+
+    auto vfs = VirtualFileSystem::fromURI(".");
+    auto err = vfs.create_dir(folderName);
+    ASSERT_TRUE(err == VirtualFileSystemStatus::VFS_OK || err == VirtualFileSystemStatus::VFS_FILEEXISTS);
+
+    // Remove existing files
+    auto files = VirtualFileSystem::globAll(folderName + "/*");
+    for (const auto &uri : files) {
+        vfs.remove(uri);
+    }
+
+    auto fileInPattern = folderName + "/" + "orc_write_test.orc";
+    auto fileOutPattern = folderName + "/" + "orc_write_test.*.orc";
+
+    ds.toorc(fileInPattern);
+    auto expectedOutput = ds.collect();
+    auto numRows = expectedOutput->rowCount();
+    auto columnNames = ds.columns();
+
+    auto outFiles = VirtualFileSystem::globAll(fileOutPattern);
+    std::vector<std::string> testOutput;
+    testOutput.reserve(numRows);
+    for (const auto &fileName : outFiles) {
+        auto filePtr = VirtualFileSystem::open_file(fileName, VirtualFileMode::VFS_READ);
+        ASSERT_TRUE(filePtr != nullptr);
+        filePtr->close();
+
+        using namespace orc;
+        ORC_UNIQUE_PTR<InputStream> inStream = readLocalFile(fileName.toPath());
+        ReaderOptions options;
+        ORC_UNIQUE_PTR<Reader> reader = createReader(std::move(inStream), options);
+
+        RowReaderOptions rowReaderOptions;
+        ORC_UNIQUE_PTR<RowReader> rowReader = reader->createRowReader(rowReaderOptions);
+
+        std::string line;
+        ORC_UNIQUE_PTR<ColumnPrinter> printer = createColumnPrinter(line, &rowReader->getSelectedType());
+
+        auto batch = rowReader->createRowBatch(numRows);
+        while (rowReader->next(*batch)) {
+            printer->reset(*batch);
+            for (uint64_t i = 0; i < batch->numElements; ++i) {
+                line.clear();
+                printer->printRow(i);
+                testOutput.push_back(line);
+            }
+        }
+    }
+
+    ASSERT_EQ(testOutput.size(), numRows);
+    for (int i = 0; i < numRows; ++i) {
+        auto expectedRow = rowToORCString(expectedOutput->getNextRow(), columnNames);
+        ASSERT_EQ(expectedRow, testOutput.at(i));
+    }
+}
+
+TEST(ORC, RowToStr) {
+    using namespace tuplex;
+    std::vector<std::string> cols({"one", "two", "three"});
+
+    auto row1 = Row(1, 2, 3);
+    EXPECT_EQ(R"({"": 1, "": 2, "": 3})", rowToORCString(row1));
+    EXPECT_EQ(R"({"one": 1, "two": 2, "three": 3})", rowToORCString(row1, cols));
+
+    auto row2 = Row(1.1, 2.2, 3.3);
+    EXPECT_EQ(R"({"": 1.1, "": 2.2, "": 3.3})", rowToORCString(row2));
+    EXPECT_EQ(R"({"one": 1.1, "two": 2.2, "three": 3.3})", rowToORCString(row2, cols));
+
+    auto row3 = Row(true, true, false);
+    EXPECT_EQ(R"({"": true, "": true, "": false})", rowToORCString(row3));
+    EXPECT_EQ(R"({"one": true, "two": true, "three": false})", rowToORCString(row3, cols));
+
+    auto row4 = Row("abc", "de", "f");
+    EXPECT_EQ(R"({"": "abc", "": "de", "": "f"})", rowToORCString(row4));
+    EXPECT_EQ(R"({"one": "abc", "two": "de", "three": "f"})", rowToORCString(row4, cols));
+
+    auto row5 = Row(Tuple(1, Tuple(2, 3)), Tuple(Tuple(4, 5), 6, 7, Tuple(8,9)), 10);
+    EXPECT_EQ(R"({"": {"": 1, "": {"": 2, "": 3}}, "": {"": {"": 4, "": 5}, "": 6, "": 7, "": {"": 8, "": 9}}, "": 10})", rowToORCString(row5));
+    EXPECT_EQ(R"({"one": {"": 1, "": {"": 2, "": 3}}, "two": {"": {"": 4, "": 5}, "": 6, "": 7, "": {"": 8, "": 9}}, "three": 10})", rowToORCString(row5, cols));
+
+    auto row6 = Row(List(1,2,3), List(1.1, 2.2, 3.3), List(true));
+    EXPECT_EQ(R"({"": [1, 2, 3], "": [1.1, 2.2, 3.3], "": [true]})", rowToORCString(row6));
+
+    std::string i64_to_f64 = std::string(R"({"1":1.1,"2":2.2,"3":3.3})");
+    std::string f64_to_i64 = std::string(R"({"1.1":1,"2.2":2,"3.3":3})");
+    std::string str_to_bool = std::string(R"({"a":true,"b":false,"c":true})");
+    std::string bool_to_str = std::string(R"({"true":"a","false":"b","true":"c"})");
+    auto row7 = Row(Field::from_str_data(i64_to_f64, python::Type::makeDictionaryType(python::Type::I64, python::Type::F64)),
+                    Field::from_str_data(f64_to_i64, python::Type::makeDictionaryType(python::Type::F64, python::Type::I64)),
+                    Field::from_str_data(str_to_bool, python::Type::makeDictionaryType(python::Type::STRING, python::Type::BOOLEAN)),
+                    Field::from_str_data(bool_to_str, python::Type::makeDictionaryType(python::Type::BOOLEAN, python::Type::STRING)));
+    EXPECT_EQ(R"({"": [{"key": 1, "value": 1.1}, {"key": 2, "value": 2.2}, {"key": 3, "value": 3.3}], "": [{"key": 1.1, "value": 1}, {"key": 2.2, "value": 2}, {"key": 3.3, "value": 3}], "": [{"key": "a", "value": true}, {"key": "b", "value": false}, {"key": "c", "value": true}], "": [{"key": true, "value": "a"}, {"key": false, "value": "b"}, {"key": true, "value": "c"}]})", rowToORCString(row7));
+
+    auto row8 = Row(1, option<int>::none, 2);
+    EXPECT_EQ(R"({"": 1, "": null, "": 2})", rowToORCString(row8));
 }
 
 tuplex::Field keyToField(cJSON *entry, const python::Type& type) {
@@ -254,7 +409,7 @@ std::string fieldToORCString(const tuplex::Field &field, const python::Type& typ
     return "";
 }
 
-std::string rowToORCString(const tuplex::Row &row, const std::vector<std::string>& columnNames = {}) {
+std::string rowToORCString(const tuplex::Row &row, const std::vector<std::string>& columnNames) {
     auto columnTypes = row.getSchema().getRowType().parameters();
     std::string s = "{";
     for (int i = 0; i < row.getNumColumns(); ++i) {
@@ -271,115 +426,4 @@ std::string rowToORCString(const tuplex::Row &row, const std::vector<std::string
     }
     s += "}";
     return s;
-}
-
-void writeDataSet(tuplex::DataSet &ds) {
-    using namespace tuplex;
-
-    std::string fileInPattern("orc_write_test.orc");
-    auto fileOutPattern = "orc_write_test.*.orc";
-
-    // Remove any files that already exist
-    auto vfs = VirtualFileSystem::fromURI(".");
-    auto files = VirtualFileSystem::globAll(fileOutPattern);
-    for (const auto& uri : files) {
-        vfs.remove(uri);
-    }
-
-    ds.toorc(fileInPattern);
-    auto rows = ds.collectAsVector();
-    auto columnNames = ds.columns();
-
-    auto outFiles = VirtualFileSystem::globAll(fileOutPattern);
-    std::vector<std::string> results;
-    for (const auto& fileName : outFiles) {
-        auto filePtr = VirtualFileSystem::open_file(fileName, VirtualFileMode::VFS_READ);
-        EXPECT_TRUE(filePtr != nullptr);
-
-        using namespace orc;
-        ORC_UNIQUE_PTR<InputStream> inStream = readLocalFile(fileName.toPath());
-        ReaderOptions options;
-        ORC_UNIQUE_PTR<Reader> reader = createReader(std::move(inStream), options);
-
-        RowReaderOptions rowReaderOptions;
-        ORC_UNIQUE_PTR<RowReader> rowReader = reader->createRowReader(rowReaderOptions);
-
-        std::string line;
-        ORC_UNIQUE_PTR<ColumnPrinter> printer = createColumnPrinter(line, &rowReader->getSelectedType());
-
-        auto batch = rowReader->createRowBatch(rows.size());
-        while (rowReader->next(*batch)) {
-            printer->reset(*batch);
-            for (uint64_t i = 0; i < batch->numElements; ++i) {
-                line.clear();
-                printer->printRow(i);
-                results.push_back(line);
-            }
-        }
-    }
-
-    EXPECT_EQ(results.size(), rows.size());
-    for (int i = 0; i < rows.size(); ++i) {
-        EXPECT_EQ(rowToORCString(rows.at(i), columnNames), results.at(i));
-    }
-}
-
-void writeCSVInput(const std::string &path) {
-    using namespace tuplex;
-    ContextOptions co = ContextOptions::defaults();
-    Context context(co);
-    auto& ds = context.csv(path);
-    writeDataSet(ds);
-}
-
-void writeRowInput(const std::vector<tuplex::Row> &rows, const std::vector<std::string>& columnNames) {
-    using namespace tuplex;
-    ContextOptions co = ContextOptions::defaults();
-    Context context(co);
-    auto& ds = context.parallelize(rows);
-    if (!columnNames.empty()) {
-        ds.setColumns(columnNames);
-    }
-    writeDataSet(ds);
-}
-
-TEST(ORC, RowToStr) {
-    using namespace tuplex;
-    std::vector<std::string> cols({"one", "two", "three"});
-
-    auto row1 = Row(1, 2, 3);
-    EXPECT_EQ(R"({"": 1, "": 2, "": 3})", rowToORCString(row1));
-    EXPECT_EQ(R"({"one": 1, "two": 2, "three": 3})", rowToORCString(row1, cols));
-
-    auto row2 = Row(1.1, 2.2, 3.3);
-    EXPECT_EQ(R"({"": 1.1, "": 2.2, "": 3.3})", rowToORCString(row2));
-    EXPECT_EQ(R"({"one": 1.1, "two": 2.2, "three": 3.3})", rowToORCString(row2, cols));
-
-    auto row3 = Row(true, true, false);
-    EXPECT_EQ(R"({"": true, "": true, "": false})", rowToORCString(row3));
-    EXPECT_EQ(R"({"one": true, "two": true, "three": false})", rowToORCString(row3, cols));
-
-    auto row4 = Row("abc", "de", "f");
-    EXPECT_EQ(R"({"": "abc", "": "de", "": "f"})", rowToORCString(row4));
-    EXPECT_EQ(R"({"one": "abc", "two": "de", "three": "f"})", rowToORCString(row4, cols));
-
-    auto row5 = Row(Tuple(1, Tuple(2, 3)), Tuple(Tuple(4, 5), 6, 7, Tuple(8,9)), 10);
-    EXPECT_EQ(R"({"": {"": 1, "": {"": 2, "": 3}}, "": {"": {"": 4, "": 5}, "": 6, "": 7, "": {"": 8, "": 9}}, "": 10})", rowToORCString(row5));
-    EXPECT_EQ(R"({"one": {"": 1, "": {"": 2, "": 3}}, "two": {"": {"": 4, "": 5}, "": 6, "": 7, "": {"": 8, "": 9}}, "three": 10})", rowToORCString(row5, cols));
-
-    auto row6 = Row(List(1,2,3), List(1.1, 2.2, 3.3), List(true));
-    EXPECT_EQ(R"({"": [1, 2, 3], "": [1.1, 2.2, 3.3], "": [true]})", rowToORCString(row6));
-
-    std::string i64_to_f64 = std::string(R"({"1":1.1,"2":2.2,"3":3.3})");
-    std::string f64_to_i64 = std::string(R"({"1.1":1,"2.2":2,"3.3":3})");
-    std::string str_to_bool = std::string(R"({"a":true,"b":false,"c":true})");
-    std::string bool_to_str = std::string(R"({"true":"a","false":"b","true":"c"})");
-    auto row7 = Row(Field::from_str_data(i64_to_f64, python::Type::makeDictionaryType(python::Type::I64, python::Type::F64)),
-                    Field::from_str_data(f64_to_i64, python::Type::makeDictionaryType(python::Type::F64, python::Type::I64)),
-                    Field::from_str_data(str_to_bool, python::Type::makeDictionaryType(python::Type::STRING, python::Type::BOOLEAN)),
-                    Field::from_str_data(bool_to_str, python::Type::makeDictionaryType(python::Type::BOOLEAN, python::Type::STRING)));
-    EXPECT_EQ(R"({"": [{"key": 1, "value": 1.1}, {"key": 2, "value": 2.2}, {"key": 3, "value": 3.3}], "": [{"key": 1.1, "value": 1}, {"key": 2.2, "value": 2}, {"key": 3.3, "value": 3}], "": [{"key": "a", "value": true}, {"key": "b", "value": false}, {"key": "c", "value": true}], "": [{"key": true, "value": "a"}, {"key": false, "value": "b"}, {"key": true, "value": "c"}]})", rowToORCString(row7));
-
-    auto row8 = Row(1, option<int>::none, 2);
-    EXPECT_EQ(R"({"": 1, "": null, "": 2})", rowToORCString(row8));
 }

--- a/tuplex/utils/include/Serializer.h
+++ b/tuplex/utils/include/Serializer.h
@@ -155,8 +155,6 @@ namespace tuplex {
 
         Schema getSchema()  { fixSchema(); return _schema; }
 
-        void setSchema(Schema schema) { _schema = schema; }
-
         /*!
          * serializes data to the buffer if there is enough capacity left
          * @param ptr memory location to where to serialize data to


### PR DESCRIPTION
1. Update Orc Tests to use the Python interpreter
2. Update ORc Cmake lists to search for local installs of zlib, ls4, and zstd on macOS.