### PR TITLE
[CI-FIX] Facilitate pip creation by better checks in build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ tuplex.egg-info/
 
 wheelhouse/
 *.zip
+tuplex/other/tplxlam.zip

--- a/scripts/build_wheel_linux.sh
+++ b/scripts/build_wheel_linux.sh
@@ -21,6 +21,18 @@ export TUPLEX_BUILD_ALL=0
 export CIBW_ARCHS_LINUX=x86_64
 export CIBW_MANYLINUX_X86_64_IMAGE='registry-1.docker.io/tuplex/ci:latest'
 
+
+# check whether lambda zip was build and stored in build-lambda
+TUPLEX_LAMBDA_ZIP=${TUPLEX_LAMBDA_ZIP:-build-lambda/tplxlam.zip}
+
+
+echo "work dir is: $(pwd)"
+if [[ -f "${TUPLEX_LAMBDA_ZIP}" ]]; then
+	echo "Found lambda runner ${TUPLEX_LAMBDA_ZIP}, adding to package"
+	mkdir -p tuplex/other
+	cp ${TUPLEX_LAMBDA_ZIP} tuplex/other/tplxlam.zip
+fi
+
 export CIBW_ENVIRONMENT="TUPLEX_LAMBDA_ZIP='./tuplex/other/tplxlam.zip' CMAKE_ARGS='-DBUILD_WITH_ORC=ON' LD_LIBRARY_PATH=/usr/local/lib:/opt/lib"
 
 # Use the following line to build only python3.9 wheel
@@ -39,6 +51,9 @@ export CIBW_SKIP="*-musllinux_*"
 
 export CIBW_BUILD_VERBOSITY=3
 export CIBW_PROJECT_REQUIRES_PYTHON=">=3.7"
+
+
+
 
 cibuildwheel --platform linux .
 

--- a/setup.py
+++ b/setup.py
@@ -233,22 +233,26 @@ class CMakeBuild(build_ext):
                 if os.path.isfile(alt_path):
                     logging.info('Found tplxlam.zip under {}, using...'.format(alt_path))
                     lambda_zip = alt_path
+                else:
+                    logging.warn("Tuplex Lambda runner not found, not packaging.")
+                    lambda_zip = None
 
-            logging.info('Packaging Tuplex Lambda runner')
+            if lambda_zip and os.path.isfile(lambda_zip):
+                logging.info('Packaging Tuplex Lambda runner')
 
-            # need to copy / link zip file into temp dir
-            # -> this is the root setup.py file, hence find root
-            logging.info('Root path is: {}'.format(tplx_package_root))
-            zip_target = os.path.join(self.build_temp, 'tuplex', 'other')
-            os.makedirs(zip_target, exist_ok=True)
-            zip_dest = os.path.join(zip_target, 'tplxlam.zip')
-            shutil.copyfile(lambda_zip, zip_dest)
-            logging.info('Copied {} to {}'.format(lambda_zip, zip_dest))
+                # need to copy / link zip file into temp dir
+                # -> this is the root setup.py file, hence find root
+                logging.info('Root path is: {}'.format(tplx_package_root))
+                zip_target = os.path.join(self.build_temp, 'tuplex', 'other')
+                os.makedirs(zip_target, exist_ok=True)
+                zip_dest = os.path.join(zip_target, 'tplxlam.zip')
+                shutil.copyfile(lambda_zip, zip_dest)
+                logging.info('Copied {} to {}'.format(lambda_zip, zip_dest))
 
-            alt_dest = os.path.join(tplx_lib_root, 'other')
-            os.makedirs(alt_dest, exist_ok=True)
-            shutil.copyfile(lambda_zip, os.path.join(alt_dest, 'tplxlam.zip'))
-            logging.info('Copied {} to {} as well'.format(lambda_zip, os.path.join(alt_dest, 'tplxlam.zip')))
+                alt_dest = os.path.join(tplx_lib_root, 'other')
+                os.makedirs(alt_dest, exist_ok=True)
+                shutil.copyfile(lambda_zip, os.path.join(alt_dest, 'tplxlam.zip'))
+                logging.info('Copied {} to {} as well'.format(lambda_zip, os.path.join(alt_dest, 'tplxlam.zip')))
 
         # get from BuildType info
         cfg = build_config['BUILD_TYPE']
@@ -587,7 +591,7 @@ def tplx_package_data():
 
     # package lambda as well?
     lambda_zip = os.environ.get('TUPLEX_LAMBDA_ZIP', None)
-    if lambda_zip:
+    if lambda_zip and os.path.isfile(lambda_zip):
         package_data['tuplex.other'] = ['*.zip']
     return package_data
 


### PR DESCRIPTION
In order to build a pip package incl. the Lambda runner, with this PR it's sufficient to simply invoke

1. ./scripts/create_lambda_zip.sh
2. ./scripts/build_wheel_linux.sh
