### PR TITLE
[CIFIX] Ubuntu 18.04 Runner fixes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ jobs:
         displayName: 'Install MongoDB'
       - script: sudo bash scripts/ubuntu1804/install_reqs.sh
         displayName: 'Install required packages'
-      - script: sudo apt-get install -y python3-setuptools ninja-build && sudo apt-get remove -y python-pexpect python3-pexpect && sudo python3.7 -m pip install --upgrade pip && sudo python3.7 -m pip uninstall -y pygments && sudo python3.7 -m pip install pytest pygments>=2.4.1 pexpect setuptools astor PyYAML jupyter nbformat pymongo eventlet==0.30.0 gunicorn pymongo && jupyter --version
+      - script: sudo apt-get install -y python3-setuptools ninja-build && sudo apt-get remove -y python-pexpect python3-pexpect && sudo python3.7 -m pip install --upgrade pip && sudo python3.7 -m pip uninstall -y pygments && sudo python3.7 -m pip install pytest pygments>=2.4.1 MarkupSafe==2.0 pexpect setuptools astor PyYAML jupyter nbformat pymongo eventlet==0.30.0 gunicorn pymongo && jupyter --version
         displayName: 'Install python dependencies'
       - script: TUPLEX_BUILD_ALL=1 CMAKE_ARGS="-DBUILD_WITH_ORC=ON -DLLVM_ROOT_DIR=/usr/lib/llvm-9 -DCMAKE_BUILD_TYPE=Release -DBUILD_FOR_CI=ON" python3 setup.py install --user
         displayName: 'Build Tuplex'

--- a/setup.py
+++ b/setup.py
@@ -464,6 +464,8 @@ class CMakeBuild(build_ext):
         if not os.path.isfile(tuplexso_path):
             print('Could not find file tuplex.so under {}, searching for it...'.format(tuplexso_path))
             paths = find_files("*tuplex*.so", self.build_temp)
+            # filter out runtime
+            paths = list(filter(lambda p: 'runtime' not in os.path.basename(p), paths))
             assert len(paths) > 0, 'did not find any file under {}'.format(self.build_temp)
             print('Found following paths: {}'.format(''.join(paths)))
             print('Using {}'.format(paths[0]))

--- a/tuplex/utils/CMakeLists.txt
+++ b/tuplex/utils/CMakeLists.txt
@@ -64,6 +64,11 @@ else()
     # Note: alternative is to use CJSON_HIDE_SYMBOLS IWTH AWS SDK.
 endif()
 
+# AWS SDK defines cjson since v1.5, yet if using BUILD_WITH_AWS=OFF make sure to add cJSON symbols...
+if(NOT BUILD_WITH_AWS)
+    list(APPEND SOURCES ${cjson_SOURCE_DIR}/cJSON.c)
+endif()
+
 add_library(libutils OBJECT
         ${CMAKE_CURRENT_BINARY_DIR} ${SOURCES} ${INCLUDES})
 set_target_properties(libutils PROPERTIES PREFIX "")
@@ -89,11 +94,6 @@ include_directories(${json_INCLUDE_DIR})
 # dependencies
 
 add_dependencies(libutils fmt spdlog json)
-
-# AWS SDK defines cjson since v1.5
-if(NOT BUILD_WITH_AWS)
-target_sources(libutils PUBLIC ${cjson_SOURCE_DIR}/cJSON.c)
-endif()
 
 target_include_directories(libutils PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/include


### PR DESCRIPTION
Fix Ubuntu 18.04 runner on Azure pipelines. 

Details:
- Force install MarkupSafe==2.0 because pip dependency resolver fails
- Correct searching for C-extension in root-level setup.py
- Fix cJSON duplicate symbol error when CMake build is configured with -DBUILD_WITH_AWS=OFF

authored-by: Leonhard Spiegelberg <leonhard@brown.edu>