### PR TITLE
[RELEASE] Tuplex v0.3.2

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -36,7 +36,7 @@ author = 'Leonhard Spiegelberg'
 # The short X.Y version
 version="0.3"
 # The full version, including alpha/beta/rc tags
-release="0.3.2rc3"
+release="0.3.2"
 
 
 # -- General configuration ---------------------------------------------------

--- a/scripts/set_version.py
+++ b/scripts/set_version.py
@@ -15,7 +15,7 @@ def LooseVersion(v):
 
 
 # to create a testpypi version use X.Y.devN
-version = '0.3.2rc3'
+version = '0.3.2'
 
 # https://pypi.org/simple/tuplex/
 # or https://test.pypi.org/simple/tuplex/

--- a/setup.py
+++ b/setup.py
@@ -596,7 +596,7 @@ def tplx_package_data():
 # logic and declaration, and simpler if you include description/version in a file.
 setup(name="tuplex",
     python_requires='>=3.7.0',
-    version="0.3.2rc3",
+    version="0.3.2",
     author="Leonhard Spiegelberg",
     author_email="tuplex@cs.brown.edu",
     description="Tuplex is a novel big data analytics framework incorporating a Python UDF compiler based on LLVM "

--- a/tuplex/historyserver/thserver/version.py
+++ b/tuplex/historyserver/thserver/version.py
@@ -1,2 +1,2 @@
 # (c) L.Spiegelberg 2017 - 2022
-__version__="0.3.2rc3"
+__version__="0.3.2"

--- a/tuplex/python/setup.py
+++ b/tuplex/python/setup.py
@@ -23,7 +23,7 @@ files = list(filter(lambda x: '__pycache__' not in x and not x.endswith('.pyc'),
 
 setup(
     name="Tuplex",
-    version="0.3.2rc3",
+    version="0.3.2",
     packages=find_packages(),
     package_data={
       # include libs in libexec

--- a/tuplex/python/tuplex/utils/version.py
+++ b/tuplex/python/tuplex/utils/version.py
@@ -1,2 +1,2 @@
 # (c) L.Spiegelberg 2017 - 2022
-__version__="0.3.2rc3"
+__version__="0.3.2"


### PR DESCRIPTION
Changelog from v0.3.1 to v.0.3.2:

Features:
- Add support for for and while loops including unrolling, type speculation and break/continue keywords
- Add preliminary support for reading/writing Apache ORC files
- Add support for builtin iterators iter, zip, enumerate, next, reversed
- Add support for is keyword
- Add list functionality to both Posix and AWS S3 file systems
- Package WebUI with auto-start (requires working installation of MongoDB)
- Add option to package experimental Lambda runner with pip package/wheel
- Add auto-setup functionality for deploying Lambda runner to AWS
- Add support for running Tuplex in Google Colab Notebooks
- Add MacOS wheel
- Switch to PyBind11 from Boost Python

Bug Fixes:

- Auto-unpacking of dictionaries with string keys works now in fallback mode as well
- Test suite now works also when invoked using multiple processes/threads
- Update various links to software in dockerfiles, install scripts
- Fix reference count issues when invoking parallelize on lists
- Fix issue with file output deleting the output directory, changed to validate directory first
- Fix bug where non-conforming rows will crash Tuplex when the majority type is a simple tuple containing var length fields due to a missing type check in parallelize.
- Fix building Tuplex on Ubuntu 20.04, add missing dependencies
- Fix auto-complete bug when using Tuplex in shell mode
- Fix calling len on empty lists
- Fix bug in aggregateByKey where source code was not correctly extracted


Committers:

Ben Givertz, Yash Gotmare, Zain Ruan, Malte Schwarzkopf, Yunzhi Shao, Leonhard Spiegelberg, Rahul Yesantharao
