### PR TITLE
[HOTFIX] Fix constexpr issue for clang

### DIFF
--- a/tuplex/adapters/cpython/include/PythonHelpers.h
+++ b/tuplex/adapters/cpython/include/PythonHelpers.h
@@ -77,6 +77,17 @@ namespace python {
         }
     }
 
+    inline PyObject* boolean(bool val) { return boolToPython(val); }
+
+    /*!
+     * returns Py_None after calling incref, similar to Py_RETURN_NONE
+     * @return Py_None
+     */
+    inline PyObject* none() {
+        Py_XINCREF(Py_None);
+        return Py_None;
+    }
+
     /*!
      * set python home to local directory
      * @param home_dir string pointing to local path where standard python libraries are stored.

--- a/tuplex/adapters/cpython/src/PythonHelpers.cc
+++ b/tuplex/adapters/cpython/src/PythonHelpers.cc
@@ -1462,7 +1462,8 @@ namespace python {
         if(python::Type::STRING == t)
             return reinterpret_cast<PyObject*>(&PyUnicode_Type);
         if(python::Type::NULLVALUE == t) {
-            auto none = Py_RETURN_NONE;
+            Py_XINCREF(Py_None);
+            auto none = Py_None;
             auto typeobj = reinterpret_cast<PyObject*>(Py_None->ob_type);
             Py_XDECREF(none);
             return typeobj;

--- a/tuplex/adapters/cpython/src/PythonHelpers.cc
+++ b/tuplex/adapters/cpython/src/PythonHelpers.cc
@@ -1444,6 +1444,7 @@ namespace python {
         return python::Type::UNKNOWN;
     }
 
+    // @TODO: inc type objects??
     PyObject* encodePythonSchema(const python::Type& t) {
         // unknown?
         // maybe special type?
@@ -1460,8 +1461,12 @@ namespace python {
             return reinterpret_cast<PyObject*>(&PyFloat_Type);
         if(python::Type::STRING == t)
             return reinterpret_cast<PyObject*>(&PyUnicode_Type);
-        if(python::Type::NULLVALUE == t)
-            return reinterpret_cast<PyObject*>(Py_None->ob_type);
+        if(python::Type::NULLVALUE == t) {
+            auto none = Py_RETURN_NONE;
+            auto typeobj = reinterpret_cast<PyObject*>(Py_None->ob_type);
+            Py_XDECREF(none);
+            return typeobj;
+        }
 
         // empty tuple handled below...
         if(python::Type::GENERICTUPLE == t)

--- a/tuplex/adapters/cpython/src/PythonSerializer.cc
+++ b/tuplex/adapters/cpython/src/PythonSerializer.cc
@@ -187,8 +187,8 @@ namespace tuplex {
                 for(size_t i=0; i<numElements; i++) {
                     PyObject* element;
                     if(elementType == python::Type::NULLVALUE) {
-                        element = Py_None;
                         Py_XINCREF(Py_None);
+                        element = Py_None;
                     } else if(elementType == python::Type::EMPTYDICT) {
                         element = PyDict_New();
                     } else if(elementType == python::Type::EMPTYTUPLE) {
@@ -252,8 +252,8 @@ namespace tuplex {
                         auto underlyingType = elementType.getReturnType();
                         if(underlyingType == python::Type::BOOLEAN) {
                             if(bitmapV[i]) {
-                                Py_XINCREF(Py_None);
                                 element = Py_None;
+                                Py_XINCREF(Py_None);
                             } else {
                                 element = PyBool_FromLong(*reinterpret_cast<const int64_t*>(ptr));
                                 ptr += sizeof(int64_t);

--- a/tuplex/codegen/src/StandardModules.cc
+++ b/tuplex/codegen/src/StandardModules.cc
@@ -101,7 +101,7 @@ namespace tuplex {
             // inf/nan since version 3.5
             // tau since version 3.6
             // use here C constants. Note, python might have depending on version different constants.
-            m->addAttribute(Symbol::makeConstant("nan", Field(D_NAN)));
+            m->addAttribute(Symbol::makeConstant("nan", Field(DOUBLE_QUIET_NAN)));
             m->addAttribute(Symbol::makeConstant("inf", Field(INFINITY)));
             m->addAttribute(Symbol::makeConstant("pi", Field(Py_MATH_PI))); // C constant M_PI
             m->addAttribute(Symbol::makeConstant("e", Field(Py_MATH_E))); // C constant M_E

--- a/tuplex/core/src/HybridHashTable.cc
+++ b/tuplex/core/src/HybridHashTable.cc
@@ -366,7 +366,7 @@ namespace tuplex {
             ptr += row_size;
             auto obj = python::rowToPython(r);
             if(!obj)
-                PyList_SET_ITEM(L, i, Py_RETURN_NONE);
+                PyList_SET_ITEM(L, i, python::none());
             else
                 PyList_SET_ITEM(L, i, obj);
         }

--- a/tuplex/core/src/HybridHashTable.cc
+++ b/tuplex/core/src/HybridHashTable.cc
@@ -366,7 +366,7 @@ namespace tuplex {
             ptr += row_size;
             auto obj = python::rowToPython(r);
             if(!obj)
-                PyList_SET_ITEM(L, i, Py_None);
+                PyList_SET_ITEM(L, i, Py_RETURN_NONE);
             else
                 PyList_SET_ITEM(L, i, obj);
         }

--- a/tuplex/core/src/TraceVisitor.cc
+++ b/tuplex/core/src/TraceVisitor.cc
@@ -89,8 +89,7 @@ namespace tuplex {
 
     // leaf nodes
     void TraceVisitor::visit(NNone *node) {
-        Py_INCREF(Py_None);
-        addTraceResult(node, TraceItem(Py_None));
+        addTraceResult(node, TraceItem(Py_RETURN_NONE));
     }
 
     void TraceVisitor::visit(NNumber *node) {
@@ -144,7 +143,7 @@ namespace tuplex {
     }
 
     void TraceVisitor::visit(NBoolean *node) {
-       addTraceResult(node, TraceItem(node->_value ? Py_True : Py_False));
+       addTraceResult(node, TraceItem(node->_value ? Py_RETURN_TRUE : Py_RETURN_FALSE));
     }
 
     void TraceVisitor::visit(NString *node) {
@@ -433,7 +432,7 @@ namespace tuplex {
                 bool finalResult = (ti_vals[i+1].value == res.value);
                 // invert result if op is ISNOT.
                 finalResult = (op == TokenType::IS) ? finalResult : !finalResult;
-                res.value = finalResult ? Py_True : Py_False;
+                res.value = finalResult ? Py_RETURN_TRUE : Py_RETURN_FALSE;
             } else {
                 auto it = cmpLookup.find(op);
                 if(it == cmpLookup.end())
@@ -862,7 +861,7 @@ namespace tuplex {
 
             // number?
             if(item.value == Py_True || item.value == Py_False) {
-                int64_t val = item.value == Py_True ? 1 : 0;
+                int64_t val = (item.value == Py_True) ? 1 : 0;
                 if(node->annotation().numTimesVisited == 0) { // init
                     node->annotation().iMin = std::numeric_limits<int64_t>::max();
                     node->annotation().iMax = std::numeric_limits<int64_t>::min();

--- a/tuplex/core/src/TraceVisitor.cc
+++ b/tuplex/core/src/TraceVisitor.cc
@@ -89,7 +89,7 @@ namespace tuplex {
 
     // leaf nodes
     void TraceVisitor::visit(NNone *node) {
-        addTraceResult(node, TraceItem(Py_RETURN_NONE));
+        addTraceResult(node, TraceItem(python::none()));
     }
 
     void TraceVisitor::visit(NNumber *node) {
@@ -143,7 +143,7 @@ namespace tuplex {
     }
 
     void TraceVisitor::visit(NBoolean *node) {
-       addTraceResult(node, TraceItem(node->_value ? Py_RETURN_TRUE : Py_RETURN_FALSE));
+       addTraceResult(node, TraceItem(python::boolToPython(node->_value)));
     }
 
     void TraceVisitor::visit(NString *node) {
@@ -432,7 +432,7 @@ namespace tuplex {
                 bool finalResult = (ti_vals[i+1].value == res.value);
                 // invert result if op is ISNOT.
                 finalResult = (op == TokenType::IS) ? finalResult : !finalResult;
-                res.value = finalResult ? Py_RETURN_TRUE : Py_RETURN_FALSE;
+                res.value = python::boolean(finalResult);
             } else {
                 auto it = cmpLookup.find(op);
                 if(it == cmpLookup.end())

--- a/tuplex/core/src/physical/ResolveTask.cc
+++ b/tuplex/core/src/physical/ResolveTask.cc
@@ -540,7 +540,7 @@ default:
                 PyTuple_SET_ITEM(args, i + 1, _py_intermediates[i]);
             }
 
-            auto kwargs = PyDict_New(); PyDict_SetItemString(kwargs, "parse_cells", parse_cells ? Py_True : Py_False);
+            auto kwargs = PyDict_New(); PyDict_SetItemString(kwargs, "parse_cells", parse_cells ? Py_RETURN_TRUE : Py_RETURN_FALSE);
             auto pcr = python::callFunctionEx(_interpreterFunctor, args, kwargs);
 
             if(pcr.exceptionCode != ExceptionCode::SUCCESS) {
@@ -1325,7 +1325,7 @@ default:
 
                 assert(_htable.hybrid_hm);
                 int rc =((HybridLookupTable*)_htable.hybrid_hm)->putItem(rowObject, nullptr);
-                // could also invoke via PyObject_SetItem(_htable.hybrid_hm, rowObject, Py_None);
+                // could also invoke via PyObject_SetItem(_htable.hybrid_hm, rowObject, Py_RETURN_NONE);
                 if(PyErr_Occurred()) {
                     PyErr_Print();
                     cout<<endl;

--- a/tuplex/core/src/physical/ResolveTask.cc
+++ b/tuplex/core/src/physical/ResolveTask.cc
@@ -540,7 +540,7 @@ default:
                 PyTuple_SET_ITEM(args, i + 1, _py_intermediates[i]);
             }
 
-            auto kwargs = PyDict_New(); PyDict_SetItemString(kwargs, "parse_cells", parse_cells ? Py_RETURN_TRUE : Py_RETURN_FALSE);
+            auto kwargs = PyDict_New(); PyDict_SetItemString(kwargs, "parse_cells", python::boolean(parse_cells));
             auto pcr = python::callFunctionEx(_interpreterFunctor, args, kwargs);
 
             if(pcr.exceptionCode != ExceptionCode::SUCCESS) {
@@ -1325,7 +1325,7 @@ default:
 
                 assert(_htable.hybrid_hm);
                 int rc =((HybridLookupTable*)_htable.hybrid_hm)->putItem(rowObject, nullptr);
-                // could also invoke via PyObject_SetItem(_htable.hybrid_hm, rowObject, Py_RETURN_NONE);
+                // could also invoke via PyObject_SetItem(_htable.hybrid_hm, rowObject, python::none());
                 if(PyErr_Occurred()) {
                     PyErr_Print();
                     cout<<endl;

--- a/tuplex/python/src/PythonContext.cc
+++ b/tuplex/python/src/PythonContext.cc
@@ -727,7 +727,7 @@ namespace tuplex {
                     if (item) {
                         PyTuple_SET_ITEM(tupleObj, j, item);
                     } else {
-                        PyTuple_SET_ITEM(tupleObj, j, Py_RETURN_NONE);
+                        PyTuple_SET_ITEM(tupleObj, j, python::none());
                     }
 
                     ++j;
@@ -1066,7 +1066,7 @@ namespace tuplex {
                 ++i;
             }
             while (i < numSample) {
-                PyList_SET_ITEM(listColObj, i, Py_RETURN_NONE);
+                PyList_SET_ITEM(listColObj, i, python::none());
                 ++i;
             }
 

--- a/tuplex/python/src/PythonContext.cc
+++ b/tuplex/python/src/PythonContext.cc
@@ -183,7 +183,7 @@ namespace tuplex {
             } else {
                 // auto upcast?
                 if(upcast && (obj == Py_True || obj == Py_False))
-                    val = obj == Py_True;
+                    val = (obj == Py_True);
                 else {
                     assert(i >= rowDelta);
                     fallbackRows.emplace_back(std::make_tuple(i - rowDelta, obj));
@@ -442,7 +442,7 @@ namespace tuplex {
             }
 
             if(PyBool_Check(obj)) {
-                *ptr = obj == Py_True ? 1 : 0;
+                *ptr = (obj == Py_True) ? 1 : 0;
                 ptr++;
                 *rawPtr = *rawPtr + 1;
                 numBytesSerialized += sizeof(int64_t);
@@ -727,8 +727,7 @@ namespace tuplex {
                     if (item) {
                         PyTuple_SET_ITEM(tupleObj, j, item);
                     } else {
-                        Py_XINCREF(Py_None);
-                        PyTuple_SET_ITEM(tupleObj, j, Py_None);
+                        PyTuple_SET_ITEM(tupleObj, j, Py_RETURN_NONE);
                     }
 
                     ++j;
@@ -1067,8 +1066,7 @@ namespace tuplex {
                 ++i;
             }
             while (i < numSample) {
-                Py_XINCREF(Py_None);
-                PyList_SET_ITEM(listColObj, i, Py_None);
+                PyList_SET_ITEM(listColObj, i, Py_RETURN_NONE);
                 ++i;
             }
 

--- a/tuplex/python/src/PythonDataSet.cc
+++ b/tuplex/python/src/PythonDataSet.cc
@@ -956,8 +956,7 @@ namespace tuplex {
             if(check_and_forward_signals(true)) {
                 rs->clear();
                 Py_XDECREF(listObj);
-                Py_XINCREF(Py_None);
-                return Py_None;
+                return Py_RETURN_NONE;
             }
         }
 

--- a/tuplex/python/src/PythonDataSet.cc
+++ b/tuplex/python/src/PythonDataSet.cc
@@ -956,7 +956,7 @@ namespace tuplex {
             if(check_and_forward_signals(true)) {
                 rs->clear();
                 Py_XDECREF(listObj);
-                return Py_RETURN_NONE;
+                return python::none();
             }
         }
 

--- a/tuplex/test/adapters/cpython/PythonHelperTest.cc
+++ b/tuplex/test/adapters/cpython/PythonHelperTest.cc
@@ -125,8 +125,8 @@ TEST_F(PythonHelperTest, pythonToTuplexNestedTupleII) {
 TEST_F(PythonHelperTest, typeMap) {
 
     // primitive types
-    EXPECT_EQ(python::Type::BOOLEAN, python::mapPythonClassToTuplexType(Py_True, false));
-    EXPECT_EQ(python::Type::BOOLEAN, python::mapPythonClassToTuplexType(Py_False, false));
+    EXPECT_EQ(python::Type::BOOLEAN, python::mapPythonClassToTuplexType(Py_RETURN_TRUE, false));
+    EXPECT_EQ(python::Type::BOOLEAN, python::mapPythonClassToTuplexType(Py_RETURN_FALSE, false));
 
     EXPECT_EQ(python::Type::I64, python::mapPythonClassToTuplexType(PyLong_FromLong(0), false));
     EXPECT_EQ(python::Type::I64, python::mapPythonClassToTuplexType(PyLong_FromLong(-42), false));
@@ -145,7 +145,7 @@ TEST_F(PythonHelperTest, typeMap) {
     EXPECT_EQ(python::Type::EMPTYTUPLE, python::mapPythonClassToTuplexType(c1, false));
 
     PyObject* c2 = PyTuple_New(5);
-    PyTuple_SetItem(c2, 0, Py_True);
+    PyTuple_SetItem(c2, 0, Py_RETURN_TRUE);
     PyTuple_SetItem(c2, 1, PyLong_FromLong(0));
     PyTuple_SetItem(c2, 2, PyFloat_FromDouble(-1.0));
     PyTuple_SetItem(c2, 3, c1);
@@ -155,21 +155,21 @@ TEST_F(PythonHelperTest, typeMap) {
 
     // dict (keytype, valuetype)
     PyObject* c3 = PyDict_New();
-    PyDict_SetItemString(c3, "x", Py_True);
-    PyDict_SetItemString(c3, "y", Py_False);
+    PyDict_SetItemString(c3, "x", Py_RETURN_TRUE);
+    PyDict_SetItemString(c3, "y", Py_RETURN_FALSE);
     auto t3 = python::Type::makeDictionaryType(python::Type::STRING, python::Type::BOOLEAN);
     EXPECT_EQ(t3, python::mapPythonClassToTuplexType(c3, false));
 
     // @TODO: to represent dicts as struct type, there should be also specific type -> generic type
     PyObject* c4 = PyDict_New();
-    PyDict_SetItemString(c3, "x", Py_True);
+    PyDict_SetItemString(c3, "x", Py_RETURN_TRUE);
     PyDict_SetItemString(c3, "y", PyFloat_FromDouble(3.141));
 
     // EXPECT_EQ(...) some struct type here...
 
     // dict => generic type, i.e. mixed key/val types.
     PyObject *c5 = PyDict_New();
-    PyDict_SetItem(c5, Py_True, Py_False);
+    PyDict_SetItem(c5, Py_RETURN_TRUE, Py_RETURN_FALSE);
     PyDict_SetItem(c5, PyLong_FromLong(42), python::PyString_FromString("hello world"));
     PyDict_SetItemString(c5, "test", PyLong_FromLong(42));
     EXPECT_EQ(python::Type::GENERICDICT, python::mapPythonClassToTuplexType(c5, false));

--- a/tuplex/test/adapters/cpython/PythonHelperTest.cc
+++ b/tuplex/test/adapters/cpython/PythonHelperTest.cc
@@ -125,8 +125,8 @@ TEST_F(PythonHelperTest, pythonToTuplexNestedTupleII) {
 TEST_F(PythonHelperTest, typeMap) {
 
     // primitive types
-    EXPECT_EQ(python::Type::BOOLEAN, python::mapPythonClassToTuplexType(Py_RETURN_TRUE, false));
-    EXPECT_EQ(python::Type::BOOLEAN, python::mapPythonClassToTuplexType(Py_RETURN_FALSE, false));
+    EXPECT_EQ(python::Type::BOOLEAN, python::mapPythonClassToTuplexType(python::boolean(true), false));
+    EXPECT_EQ(python::Type::BOOLEAN, python::mapPythonClassToTuplexType(python::boolean(false), false));
 
     EXPECT_EQ(python::Type::I64, python::mapPythonClassToTuplexType(PyLong_FromLong(0), false));
     EXPECT_EQ(python::Type::I64, python::mapPythonClassToTuplexType(PyLong_FromLong(-42), false));
@@ -145,7 +145,7 @@ TEST_F(PythonHelperTest, typeMap) {
     EXPECT_EQ(python::Type::EMPTYTUPLE, python::mapPythonClassToTuplexType(c1, false));
 
     PyObject* c2 = PyTuple_New(5);
-    PyTuple_SetItem(c2, 0, Py_RETURN_TRUE);
+    PyTuple_SetItem(c2, 0, python::boolean(true));
     PyTuple_SetItem(c2, 1, PyLong_FromLong(0));
     PyTuple_SetItem(c2, 2, PyFloat_FromDouble(-1.0));
     PyTuple_SetItem(c2, 3, c1);
@@ -155,21 +155,21 @@ TEST_F(PythonHelperTest, typeMap) {
 
     // dict (keytype, valuetype)
     PyObject* c3 = PyDict_New();
-    PyDict_SetItemString(c3, "x", Py_RETURN_TRUE);
-    PyDict_SetItemString(c3, "y", Py_RETURN_FALSE);
+    PyDict_SetItemString(c3, "x", python::boolean(true));
+    PyDict_SetItemString(c3, "y", python::boolean(false));
     auto t3 = python::Type::makeDictionaryType(python::Type::STRING, python::Type::BOOLEAN);
     EXPECT_EQ(t3, python::mapPythonClassToTuplexType(c3, false));
 
     // @TODO: to represent dicts as struct type, there should be also specific type -> generic type
     PyObject* c4 = PyDict_New();
-    PyDict_SetItemString(c3, "x", Py_RETURN_TRUE);
+    PyDict_SetItemString(c3, "x", python::boolean(true));
     PyDict_SetItemString(c3, "y", PyFloat_FromDouble(3.141));
 
     // EXPECT_EQ(...) some struct type here...
 
     // dict => generic type, i.e. mixed key/val types.
     PyObject *c5 = PyDict_New();
-    PyDict_SetItem(c5, Py_RETURN_TRUE, Py_RETURN_FALSE);
+    PyDict_SetItem(c5, python::boolean(true), python::boolean(false));
     PyDict_SetItem(c5, PyLong_FromLong(42), python::PyString_FromString("hello world"));
     PyDict_SetItemString(c5, "test", PyLong_FromLong(42));
     EXPECT_EQ(python::Type::GENERICDICT, python::mapPythonClassToTuplexType(c5, false));

--- a/tuplex/test/adapters/cpython/PythonSerializerTest.cc
+++ b/tuplex/test/adapters/cpython/PythonSerializerTest.cc
@@ -16,6 +16,7 @@
 
 #include "PythonSerializer.h"
 #include "PythonSerializer_private.h"
+#include "PythonHelpers.h"
 #include "Row.h"
 
 using namespace tuplex;

--- a/tuplex/test/adapters/cpython/PythonSerializerTest.cc
+++ b/tuplex/test/adapters/cpython/PythonSerializerTest.cc
@@ -232,7 +232,7 @@ TEST(PythonSerializer, TestCreatePyObjectFromMemoryEmptyTuple) {
     checkCreatePyObjectFromMemoryTuple(buffer, capacity, Tuple(), wrapped_tuple, true);
 
     PyObject *non_empty_tuple = PyTuple_New(1);
-    PyTuple_SetItem(non_empty_tuple, 0, Py_RETURN_NONE);
+    PyTuple_SetItem(non_empty_tuple, 0, python::none());
     wrapped_tuple = PyTuple_New(1);
     PyTuple_SetItem(wrapped_tuple, 0, non_empty_tuple);
 
@@ -246,7 +246,7 @@ TEST(PythonSerializer, TestCreatePyObjectFromMemoryAllTypesTuple) {
     uint8_t buffer[capacity];
 
     PyObject *tuple = PyTuple_New(6);
-    PyTuple_SetItem(tuple, 0, Py_RETURN_TRUE);
+    PyTuple_SetItem(tuple, 0, python::boolean(true));
     PyTuple_SetItem(tuple, 1, PyLong_FromLong(42));
     PyTuple_SetItem(tuple, 2, PyFloat_FromDouble(3.141));
     std::string str = "Hello, World!";
@@ -254,7 +254,7 @@ TEST(PythonSerializer, TestCreatePyObjectFromMemoryAllTypesTuple) {
     PyTuple_SetItem(tuple, 3, PyUnicode_DecodeASCII(str.c_str(), str.length(), string_errors));
     PyTuple_SetItem(tuple, 4, PyTuple_New(0));
     PyObject *non_empty_tuple = PyTuple_New(1);
-    PyTuple_SetItem(non_empty_tuple, 0, Py_RETURN_FALSE);
+    PyTuple_SetItem(non_empty_tuple, 0, python::boolean(false));
     PyTuple_SetItem(tuple, 5, non_empty_tuple);
 
     PyObject *wrapped_tuple = PyTuple_New(1);
@@ -293,7 +293,7 @@ TEST(PythonSerializer, TestCreatePyObjectFromMemoryNestedTuple) {
 
     PyObject *inner_tuple_1 = PyTuple_New(3);
     PyObject *inner_inner_tuple_1 = PyTuple_New(2);
-    PyTuple_SetItem(inner_inner_tuple_1, 0, Py_RETURN_TRUE);
+    PyTuple_SetItem(inner_inner_tuple_1, 0, python::boolean(true));
     PyTuple_SetItem(inner_inner_tuple_1, 1, PyFloat_FromDouble(sample_float));
     PyObject *inner_inner_tuple_2 = PyTuple_New(0);
     PyObject *inner_inner_tuple_3 = PyTuple_New(1);
@@ -339,7 +339,7 @@ TEST(PythonSerializer, TestFromSerializedMemory) {
 
     EXPECT_TRUE(fromSerializedMemory(buffer, capacity, row.getSchema(), &pyobj));
     PyObject *bool_tuple = PyTuple_New(1);
-    PyTuple_SetItem(bool_tuple, 0, Py_RETURN_TRUE);
+    PyTuple_SetItem(bool_tuple, 0, python::boolean(true));
     PyObject *wrapped_tuple = PyTuple_New(1);
     PyTuple_SetItem(wrapped_tuple, 0, bool_tuple);
     EXPECT_EQ(1, PyObject_RichCompareBool(wrapped_tuple, pyobj, Py_EQ));

--- a/tuplex/test/adapters/cpython/PythonSerializerTest.cc
+++ b/tuplex/test/adapters/cpython/PythonSerializerTest.cc
@@ -232,7 +232,7 @@ TEST(PythonSerializer, TestCreatePyObjectFromMemoryEmptyTuple) {
     checkCreatePyObjectFromMemoryTuple(buffer, capacity, Tuple(), wrapped_tuple, true);
 
     PyObject *non_empty_tuple = PyTuple_New(1);
-    PyTuple_SetItem(non_empty_tuple, 0, Py_None);
+    PyTuple_SetItem(non_empty_tuple, 0, Py_RETURN_NONE);
     wrapped_tuple = PyTuple_New(1);
     PyTuple_SetItem(wrapped_tuple, 0, non_empty_tuple);
 
@@ -246,7 +246,7 @@ TEST(PythonSerializer, TestCreatePyObjectFromMemoryAllTypesTuple) {
     uint8_t buffer[capacity];
 
     PyObject *tuple = PyTuple_New(6);
-    PyTuple_SetItem(tuple, 0, Py_True);
+    PyTuple_SetItem(tuple, 0, Py_RETURN_TRUE);
     PyTuple_SetItem(tuple, 1, PyLong_FromLong(42));
     PyTuple_SetItem(tuple, 2, PyFloat_FromDouble(3.141));
     std::string str = "Hello, World!";
@@ -254,7 +254,7 @@ TEST(PythonSerializer, TestCreatePyObjectFromMemoryAllTypesTuple) {
     PyTuple_SetItem(tuple, 3, PyUnicode_DecodeASCII(str.c_str(), str.length(), string_errors));
     PyTuple_SetItem(tuple, 4, PyTuple_New(0));
     PyObject *non_empty_tuple = PyTuple_New(1);
-    PyTuple_SetItem(non_empty_tuple, 0, Py_False);
+    PyTuple_SetItem(non_empty_tuple, 0, Py_RETURN_FALSE);
     PyTuple_SetItem(tuple, 5, non_empty_tuple);
 
     PyObject *wrapped_tuple = PyTuple_New(1);
@@ -293,7 +293,7 @@ TEST(PythonSerializer, TestCreatePyObjectFromMemoryNestedTuple) {
 
     PyObject *inner_tuple_1 = PyTuple_New(3);
     PyObject *inner_inner_tuple_1 = PyTuple_New(2);
-    PyTuple_SetItem(inner_inner_tuple_1, 0, Py_True);
+    PyTuple_SetItem(inner_inner_tuple_1, 0, Py_RETURN_TRUE);
     PyTuple_SetItem(inner_inner_tuple_1, 1, PyFloat_FromDouble(sample_float));
     PyObject *inner_inner_tuple_2 = PyTuple_New(0);
     PyObject *inner_inner_tuple_3 = PyTuple_New(1);
@@ -339,7 +339,7 @@ TEST(PythonSerializer, TestFromSerializedMemory) {
 
     EXPECT_TRUE(fromSerializedMemory(buffer, capacity, row.getSchema(), &pyobj));
     PyObject *bool_tuple = PyTuple_New(1);
-    PyTuple_SetItem(bool_tuple, 0, Py_True);
+    PyTuple_SetItem(bool_tuple, 0, Py_RETURN_TRUE);
     PyObject *wrapped_tuple = PyTuple_New(1);
     PyTuple_SetItem(wrapped_tuple, 0, bool_tuple);
     EXPECT_EQ(1, PyObject_RichCompareBool(wrapped_tuple, pyobj, Py_EQ));

--- a/tuplex/test/core/MathFunctionsTest.cc
+++ b/tuplex/test/core/MathFunctionsTest.cc
@@ -710,7 +710,7 @@ TEST_F(MathFunctionsTest, MathIsNan) {
     ce.importModuleAs("math", "math");
 
     auto v1 = c.parallelize({
-        Row(0.0), Row(D_NAN), Row(INFINITY), Row(-INFINITY)
+                                    Row(0.0), Row(DOUBLE_QUIET_NAN), Row(INFINITY), Row(-INFINITY)
     }).map(UDF("lambda x: math.isnan(x)", "", ce)).collectAsVector();
 
     EXPECT_EQ(v1.size(), 4);
@@ -737,7 +737,7 @@ TEST_F(MathFunctionsTest, MathIsNan) {
     EXPECT_EQ(v3[2].getBoolean(0), false);
 
     auto v4 = c.parallelize({
-        Row(-0.89), Row(10.23), Row(-97.484), Row(-D_NAN)
+        Row(-0.89), Row(10.23), Row(-97.484), Row(-DOUBLE_QUIET_NAN)
     }).map(UDF("lambda x: math.isnan(x)", "", ce)).collectAsVector();
     EXPECT_EQ(v4.size(), 4);
     EXPECT_EQ(v4[0].getBoolean(0), false);
@@ -762,7 +762,7 @@ TEST_F(MathFunctionsTest, MathIsInf) {
     ce.importModuleAs("math", "math");
 
     auto v1 = c.parallelize({
-        Row(M_PI), Row(D_NAN), Row(INFINITY), Row(-INFINITY)
+                                    Row(M_PI), Row(DOUBLE_QUIET_NAN), Row(INFINITY), Row(-INFINITY)
     }).map(UDF("lambda x: math.isinf(x)", "", ce)).collectAsVector();
     EXPECT_EQ(v1.size(), 4);
     EXPECT_EQ(v1[0].getBoolean(0), false);
@@ -908,7 +908,7 @@ TEST_F(MathFunctionsTest, MathIsClose) {
         Row(INFINITY, -INFINITY),
         Row(-INFINITY, -INFINITY),
         Row(INFINITY, 5),
-        Row(D_NAN, D_NAN),
+        Row(DOUBLE_QUIET_NAN, DOUBLE_QUIET_NAN),
         Row(M_PI, M_PI),
         Row(M_PI, 3.14159265)
     }).map(UDF("lambda x, y: math.isclose(x, y)", "", ce)).collectAsVector();

--- a/tuplex/test/core/PythonPipelineTest.cc
+++ b/tuplex/test/core/PythonPipelineTest.cc
@@ -360,16 +360,16 @@ TEST(PythonPipeline, BasicJoin) {
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("f64"), PyFloat_FromDouble(41.5));
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("f64"), PyFloat_FromDouble(-3.141));
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("str"), python::PyString_FromString("hello world!"));
-    PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("null"), Py_None);
+    PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("null"), Py_RETURN_NONE);
 
     // now the test objects (multiple data)
     // => note: same key, different bucket needs combined result!
     // Note: if column names are intended, then create Row objects!
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("test"), PyLong_FromLong(42));
-    PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("test"), Py_True);
+    PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("test"), Py_RETURN_TRUE);
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("test"), PyFloat_FromDouble(3.141));
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("test"), python::PyString_FromString("hello"));
-    PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("test"), Py_None);
+    PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("test"), Py_RETURN_NONE);
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("test"), PyTuple_New(0)); // ()
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("test"), PyList_New(0));  // []
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("test"), PyDict_New());          // {}
@@ -466,16 +466,16 @@ TEST(PythonPipeline, BasicIntJoin) {
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(2), PyFloat_FromDouble(41.5));
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(2), PyFloat_FromDouble(-3.141));
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(3), python::PyString_FromString("hello world!"));
-    PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(4), Py_None);
+    PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(4), Py_RETURN_NONE);
 
     // now the test objects (key 10, multiple data)
     // => note: same key, different bucket needs combined result!
     // Note: if column names are intended, then create Row objects!
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(10), PyLong_FromLong(42));
-    PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(10), Py_True);
+    PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(10), Py_RETURN_TRUE);
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(10), PyFloat_FromDouble(3.141));
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(10), python::PyString_FromString("hello"));
-    PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(10), Py_None);
+    PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(10), Py_RETURN_NONE);
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(10), PyTuple_New(0)); // ()
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(10), PyList_New(0));  // []
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(10), PyDict_New());          // {}
@@ -707,7 +707,7 @@ TEST(PythonPipeline, MultiJoin) {
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrappedB), PyLong_FromLong(10), PyLong_FromLong(99)); // wrong key-type, right bucket-type
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrappedB), python::PyString_FromString("xyz"), python::PyString_FromString("bla"));  // right key, wrong bucket value
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrappedB), PyLong_FromLong(10), python::PyString_FromString("foo")); // wrong key-type, wrong bucket-type
-    PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrappedB), python::PyString_FromString("xyz"), Py_False);  // another combo to spice it up
+    PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrappedB), python::PyString_FromString("xyz"), Py_RETURN_FALSE);  // another combo to spice it up
 
     vector<string> testData = {"abc,100,1000",
                                "10,110,1100",

--- a/tuplex/test/core/PythonPipelineTest.cc
+++ b/tuplex/test/core/PythonPipelineTest.cc
@@ -360,16 +360,16 @@ TEST(PythonPipeline, BasicJoin) {
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("f64"), PyFloat_FromDouble(41.5));
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("f64"), PyFloat_FromDouble(-3.141));
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("str"), python::PyString_FromString("hello world!"));
-    PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("null"), Py_RETURN_NONE);
+    PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("null"), python::none());
 
     // now the test objects (multiple data)
     // => note: same key, different bucket needs combined result!
     // Note: if column names are intended, then create Row objects!
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("test"), PyLong_FromLong(42));
-    PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("test"), Py_RETURN_TRUE);
+    PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("test"), python::boolean(true));
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("test"), PyFloat_FromDouble(3.141));
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("test"), python::PyString_FromString("hello"));
-    PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("test"), Py_RETURN_NONE);
+    PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("test"), python::none());
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("test"), PyTuple_New(0)); // ()
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("test"), PyList_New(0));  // []
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), python::PyString_FromString("test"), PyDict_New());          // {}
@@ -466,16 +466,16 @@ TEST(PythonPipeline, BasicIntJoin) {
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(2), PyFloat_FromDouble(41.5));
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(2), PyFloat_FromDouble(-3.141));
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(3), python::PyString_FromString("hello world!"));
-    PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(4), Py_RETURN_NONE);
+    PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(4), python::none());
 
     // now the test objects (key 10, multiple data)
     // => note: same key, different bucket needs combined result!
     // Note: if column names are intended, then create Row objects!
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(10), PyLong_FromLong(42));
-    PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(10), Py_RETURN_TRUE);
+    PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(10), python::boolean(true));
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(10), PyFloat_FromDouble(3.141));
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(10), python::PyString_FromString("hello"));
-    PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(10), Py_RETURN_NONE);
+    PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(10), python::none());
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(10), PyTuple_New(0)); // ()
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(10), PyList_New(0));  // []
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrapped), PyLong_FromLong(10), PyDict_New());          // {}
@@ -707,7 +707,7 @@ TEST(PythonPipeline, MultiJoin) {
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrappedB), PyLong_FromLong(10), PyLong_FromLong(99)); // wrong key-type, right bucket-type
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrappedB), python::PyString_FromString("xyz"), python::PyString_FromString("bla"));  // right key, wrong bucket value
     PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrappedB), PyLong_FromLong(10), python::PyString_FromString("foo")); // wrong key-type, wrong bucket-type
-    PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrappedB), python::PyString_FromString("xyz"), Py_RETURN_FALSE);  // another combo to spice it up
+    PyObject_SetItem(reinterpret_cast<PyObject*>(hm_wrappedB), python::PyString_FromString("xyz"), python::boolean(false));  // another combo to spice it up
 
     vector<string> testData = {"abc,100,1000",
                                "10,110,1100",

--- a/tuplex/test/core/PythonTracer.cc
+++ b/tuplex/test/core/PythonTracer.cc
@@ -142,7 +142,7 @@ TEST_F(TracerTest, IsKeyword) {
     python::lockGIL();
 
     auto udf1 = "lambda x: x is None";
-    PyObject* arg1 = Py_None;
+    PyObject* arg1 = Py_RETURN_NONE;
 
     traceAndValidateResult(udf1, arg1);
 
@@ -172,7 +172,7 @@ TEST_F(TracerTest, IsKeyword) {
     traceAndValidateResult(udf6, arg6);
 
     auto udf7 = "lambda x: x is 1";
-    PyObject* arg7 = Py_None;
+    PyObject* arg7 = Py_RETURN_NONE;
 
     traceAndValidateResult(udf7, arg7);
 

--- a/tuplex/test/core/PythonTracer.cc
+++ b/tuplex/test/core/PythonTracer.cc
@@ -142,7 +142,7 @@ TEST_F(TracerTest, IsKeyword) {
     python::lockGIL();
 
     auto udf1 = "lambda x: x is None";
-    PyObject* arg1 = Py_RETURN_NONE;
+    PyObject* arg1 = python::none();
 
     traceAndValidateResult(udf1, arg1);
 
@@ -172,7 +172,7 @@ TEST_F(TracerTest, IsKeyword) {
     traceAndValidateResult(udf6, arg6);
 
     auto udf7 = "lambda x: x is 1";
-    PyObject* arg7 = Py_RETURN_NONE;
+    PyObject* arg7 = python::none();
 
     traceAndValidateResult(udf7, arg7);
 

--- a/tuplex/test/wrappers/WrapperTest.cc
+++ b/tuplex/test/wrappers/WrapperTest.cc
@@ -216,7 +216,7 @@ TEST_F(WrapperTest, MixedSimpleTupleTuple) {
     PyTuple_SET_ITEM(tupleObj3, 1, PyLong_FromLong(3));
 
     PyObject *tupleObj4 = PyTuple_New(2);
-    PyTuple_SET_ITEM(tupleObj4, 0, Py_None);
+    PyTuple_SET_ITEM(tupleObj4, 0, Py_RETURN_NONE);
     PyTuple_SET_ITEM(tupleObj4, 1, PyLong_FromLong(4));
 
     PyList_SetItem(listObj, 0, tupleObj1);
@@ -309,7 +309,7 @@ TEST_F(WrapperTest, SimpleCSVParse) {
     fclose(f);
 
     PyObject * pyopt = PyDict_New();
-    PyDict_SetItemString(pyopt, "tuplex.webui.enable", Py_False);
+    PyDict_SetItemString(pyopt, "tuplex.webui.enable", Py_RETURN_FALSE);
 
     // RAII, destruct python context!
     PythonContext c("c", "", microTestOptions().asJSON());
@@ -381,7 +381,7 @@ TEST_F(WrapperTest, Show) {
     fclose(f);
 
     PyObject * pyopt = PyDict_New();
-    PyDict_SetItemString(pyopt, "tuplex.webui.enable", Py_False);
+    PyDict_SetItemString(pyopt, "tuplex.webui.enable", Py_RETURN_FALSE);
 
     // RAII, destruct python context!
     PythonContext c("python", "", microTestOptions().asJSON());
@@ -406,7 +406,7 @@ TEST_F(WrapperTest, GoogleTrace) {
     string sampleTraceFile = "../resources/gtrace-jobevents-sample.csv";
 
     PyObject * pyopt = PyDict_New();
-    PyDict_SetItemString(pyopt, "tuplex.webui.enable", Py_False);
+    PyDict_SetItemString(pyopt, "tuplex.webui.enable", Py_RETURN_FALSE);
 
     // RAII, destruct python context!
     PythonContext c("python", "", testOptions().asJSON());
@@ -703,7 +703,7 @@ TEST_F(WrapperTest, UpcastParallelizeI) {
 
         PyList_SET_ITEM(listObj, 0, PyFloat_FromDouble(2.0));
         PyList_SET_ITEM(listObj, 1, PyFloat_FromDouble(3.0));
-        PyList_SET_ITEM(listObj, 2, Py_True); // auto upcast bool --> float
+        PyList_SET_ITEM(listObj, 2, Py_RETURN_TRUE); // auto upcast bool --> float
         PyList_SET_ITEM(listObj, 3, PyLong_FromLong(10)); // auto upcast int --> float
 
         auto list = py::reinterpret_borrow<py::list>(listObj);
@@ -734,8 +734,8 @@ TEST_F(WrapperTest, UpcastParallelizeII) {
         PyObject * listObj = PyList_New(4);
 
         PyList_SET_ITEM(listObj, 0, PyLong_FromLong(3));
-        PyList_SET_ITEM(listObj, 1, Py_False); // auto upcast bool --> int
-        PyList_SET_ITEM(listObj, 2, Py_True); // auto upcast bool --> int
+        PyList_SET_ITEM(listObj, 1, Py_RETURN_FALSE); // auto upcast bool --> int
+        PyList_SET_ITEM(listObj, 2, Py_RETURN_TRUE); // auto upcast bool --> int
         PyList_SET_ITEM(listObj, 3, PyLong_FromLong(2));
 
         auto list = py::reinterpret_borrow<py::list>(listObj);
@@ -781,8 +781,7 @@ TEST_F(WrapperTest, OptionListTest) {
         PyList_SET_ITEM(listObj4, 0, listObj1);
         PyList_SET_ITEM(listObj4, 1, listObj2);
         PyList_SET_ITEM(listObj5, 0, listObj3);
-        PyList_SET_ITEM(listObj5, 1, Py_None);
-        Py_XINCREF(Py_None);
+        PyList_SET_ITEM(listObj5, 1, Py_RETURN_NONE);
         PyTuple_SET_ITEM(tupleObj1, 0, listObj4);
         PyTuple_SET_ITEM(tupleObj2, 0, listObj5);
         PyList_SET_ITEM(listObj6, 0, tupleObj1);
@@ -895,8 +894,8 @@ TEST_F(WrapperTest, IntegerTuple) {
     using namespace tuplex;
 
     PyObject* pyopt = PyDict_New();
-    PyDict_SetItemString(pyopt, "tuplex.webui.enable", Py_False);
-    PyDict_SetItemString(pyopt, "tuplex.autoUpcast", Py_True);
+    PyDict_SetItemString(pyopt, "tuplex.webui.enable", Py_RETURN_FALSE);
+    PyDict_SetItemString(pyopt, "tuplex.autoUpcast", Py_RETURN_TRUE);
 
     // RAII, destruct python context!
     auto opts = microTestOptions();
@@ -1293,7 +1292,7 @@ TEST_F(WrapperTest, OptionParallelizeI) {
     PyList_SET_ITEM(listObj, 1, Py_None);
     PyList_SET_ITEM(listObj, 2, PyLong_FromLong(213));
     PyList_SET_ITEM(listObj, 3, PyLong_FromLong(345));
-    PyList_SET_ITEM(listObj, 4, Py_None);
+    PyList_SET_ITEM(listObj, 4, Py_RETURN_NONE);
 
     // weird block syntax due to RAII problems.
     {
@@ -1306,10 +1305,10 @@ TEST_F(WrapperTest, OptionParallelizeI) {
 
         // check contents
         EXPECT_EQ(python::pythonToRow(PyList_GetItem(resObj, 0)), Row(112));
-        EXPECT_EQ(PyList_GetItem(resObj, 1), Py_None);
+        EXPECT_EQ(PyList_GetItem(resObj, 1), Py_RETURN_NONE);
         EXPECT_EQ(python::pythonToRow(PyList_GetItem(resObj, 2)), Row(213));
         EXPECT_EQ(python::pythonToRow(PyList_GetItem(resObj, 3)), Row(345));
-        EXPECT_EQ(PyList_GetItem(resObj, 4), Py_None);
+        EXPECT_EQ(PyList_GetItem(resObj, 4), Py_RETURN_NONE);
     }
 }
 
@@ -1333,10 +1332,10 @@ TEST_F(WrapperTest, OptionParallelizeII) {
     PyList_SET_ITEM(l3, 1, PyLong_FromLong(6));
 
     PyList_SET_ITEM(listObj, 0, l1);
-    PyList_SET_ITEM(listObj, 1, Py_None);
+    PyList_SET_ITEM(listObj, 1, Py_RETURN_NONE);
     PyList_SET_ITEM(listObj, 2, l2);
     PyList_SET_ITEM(listObj, 3, l3);
-    PyList_SET_ITEM(listObj, 4, Py_None);
+    PyList_SET_ITEM(listObj, 4, Py_RETURN_NONE);
 
     // weird block syntax due to RAII problems.
     {
@@ -1349,10 +1348,10 @@ TEST_F(WrapperTest, OptionParallelizeII) {
 
         // check contents
         EXPECT_EQ(python::pythonToRow(PyList_GetItem(resObj, 0)), Row(List(1, 2)));
-        EXPECT_EQ(PyList_GetItem(resObj, 1), Py_None);
+        EXPECT_EQ(PyList_GetItem(resObj, 1), Py_RETURN_NONE);
         EXPECT_EQ(python::pythonToRow(PyList_GetItem(resObj, 2)), Row(List(3, 4)));
         EXPECT_EQ(python::pythonToRow(PyList_GetItem(resObj, 3)), Row(List(5, 6)));
-        EXPECT_EQ(PyList_GetItem(resObj, 4), Py_None);
+        EXPECT_EQ(PyList_GetItem(resObj, 4), Py_RETURN_NONE);
     }
 }
 
@@ -1362,8 +1361,8 @@ TEST_F(WrapperTest, NoneParallelize) {
     PythonContext c("c", "", microTestOptions().asJSON());
 
     PyObject * listObj = PyList_New(2);
-    PyList_SET_ITEM(listObj, 0, Py_None);
-    PyList_SET_ITEM(listObj, 1, Py_None);
+    PyList_SET_ITEM(listObj, 0, Py_RETURN_NONE);
+    PyList_SET_ITEM(listObj, 1, Py_RETURN_NONE);
 
     // weird block syntax due to RAII problems.
     {
@@ -1375,8 +1374,8 @@ TEST_F(WrapperTest, NoneParallelize) {
         ASSERT_EQ(PyList_GET_SIZE(resObj), 2);
 
         // check contents
-        EXPECT_EQ(PyList_GetItem(resObj, 0), Py_None);
-        EXPECT_EQ(PyList_GetItem(resObj, 1), Py_None);
+        EXPECT_EQ(PyList_GetItem(resObj, 0), Py_RETURN_NONE);
+        EXPECT_EQ(PyList_GetItem(resObj, 1), Py_RETURN_NONE);
     }
 }
 
@@ -1401,10 +1400,10 @@ TEST_F(WrapperTest, EmptyMapI) {
         ASSERT_EQ(PyList_GET_SIZE(resObj), 4);
 
         // check contents
-        EXPECT_EQ(PyList_GetItem(resObj, 0), Py_None);
-        EXPECT_EQ(PyList_GetItem(resObj, 1), Py_None);
-        EXPECT_EQ(PyList_GetItem(resObj, 2), Py_None);
-        EXPECT_EQ(PyList_GetItem(resObj, 3), Py_None);
+        EXPECT_EQ(PyList_GetItem(resObj, 0), Py_RETURN_NONE);
+        EXPECT_EQ(PyList_GetItem(resObj, 1), Py_RETURN_NONE);
+        EXPECT_EQ(PyList_GetItem(resObj, 2), Py_RETURN_NONE);
+        EXPECT_EQ(PyList_GetItem(resObj, 3), Py_RETURN_NONE);
     }
 }
 
@@ -1497,8 +1496,8 @@ TEST_F(WrapperTest, EmptyOptionMapI) {
         EXPECT_EQ(PyTuple_GET_SIZE(PyList_GetItem(resObj, 0)), 0);
         EXPECT_TRUE(PyTuple_Check(PyList_GetItem(resObj, 1)));
         EXPECT_EQ(PyTuple_GET_SIZE(PyList_GetItem(resObj, 1)), 0);
-        EXPECT_EQ(PyList_GetItem(resObj, 2), Py_None);
-        EXPECT_EQ(PyList_GetItem(resObj, 3), Py_None);
+        EXPECT_EQ(PyList_GetItem(resObj, 2), Py_RETURN_NONE);
+        EXPECT_EQ(PyList_GetItem(resObj, 3), Py_RETURN_NONE);
     }
 }
 
@@ -1527,8 +1526,8 @@ TEST_F(WrapperTest, EmptyOptionMapII) {
         EXPECT_EQ(PyDict_Size(PyList_GetItem(resObj, 0)), 0);
         EXPECT_TRUE(PyDict_Check(PyList_GetItem(resObj, 1)));
         EXPECT_EQ(PyDict_Size(PyList_GetItem(resObj, 1)), 0);
-        EXPECT_EQ(PyList_GetItem(resObj, 2), Py_None);
-        EXPECT_EQ(PyList_GetItem(resObj, 3), Py_None);
+        EXPECT_EQ(PyList_GetItem(resObj, 2), Py_RETURN_NONE);
+        EXPECT_EQ(PyList_GetItem(resObj, 3), Py_RETURN_NONE);
     }
 }
 
@@ -1544,12 +1543,12 @@ TEST_F(WrapperTest, OptionTupleParallelizeI) {
     PyTuple_SET_ITEM(t1, 1, PyLong_FromLong(12));
 
     PyObject * t2 = PyTuple_New(2);
-    PyTuple_SET_ITEM(t2, 0, Py_None);
+    PyTuple_SET_ITEM(t2, 0, Py_RETURN_NONE);
     PyTuple_SET_ITEM(t2, 1, PyLong_FromLong(100));
 
     PyObject * t3 = PyTuple_New(2);
     PyTuple_SET_ITEM(t3, 0, PyLong_FromLong(200));
-    PyTuple_SET_ITEM(t3, 1, Py_None);
+    PyTuple_SET_ITEM(t3, 1, Py_RETURN_NONE);
 
     PyList_SET_ITEM(listObj, 0, t1);
     PyList_SET_ITEM(listObj, 1, t2);
@@ -1574,10 +1573,10 @@ TEST_F(WrapperTest, OptionTupleParallelizeI) {
 
         EXPECT_EQ(python::pythonToRow(PyTuple_GetItem(el1, 0)), Row(11));
         EXPECT_EQ(python::pythonToRow(PyTuple_GetItem(el1, 1)), Row(12));
-        EXPECT_EQ(PyTuple_GetItem(el2, 0), Py_None);
+        EXPECT_EQ(PyTuple_GetItem(el2, 0), Py_RETURN_NONE);
         EXPECT_EQ(python::pythonToRow(PyTuple_GetItem(el2, 1)), Row(100));
         EXPECT_EQ(python::pythonToRow(PyTuple_GetItem(el3, 0)), Row(200));
-        EXPECT_EQ(PyTuple_GetItem(el3, 1), Py_None);
+        EXPECT_EQ(PyTuple_GetItem(el3, 1), Py_RETURN_NONE);
     }
 }
 
@@ -2489,10 +2488,10 @@ TEST_F(WrapperTest, MixedTypesIsWithNone) {
     PythonContext c("python", "",  opts.asJSON());
 
     PyObject *listObj = PyList_New(8);
-    PyList_SetItem(listObj, 0, Py_None);
+    PyList_SetItem(listObj, 0, Py_RETURN_NONE);
     PyList_SetItem(listObj, 1, PyLong_FromLong(255));
     PyList_SetItem(listObj, 2, PyLong_FromLong(400));
-    PyList_SetItem(listObj, 3, Py_True);
+    PyList_SetItem(listObj, 3, Py_RETURN_TRUE);
     PyList_SetItem(listObj, 4, PyFloat_FromDouble(2.7));
     PyList_SetItem(listObj, 5, PyTuple_New(0)); // empty tuple
     PyList_SetItem(listObj, 6, PyList_New(0)); // empty list

--- a/tuplex/test/wrappers/WrapperTest.cc
+++ b/tuplex/test/wrappers/WrapperTest.cc
@@ -147,7 +147,7 @@ TEST_F(WrapperTest, MathIsInf) {
         PyDict_SetItemString(ba_closure, "math", math_mod);
 
         // write parallelize function
-        auto res = c.parallelize(list).map("lambda x: math.isinf(x)", "", py::reinterpret_steal<py::dict>(ba_closure)).collect();
+        auto res = c.parallelize(list).map("lambda x: math.isinf(x)", "", py::reinterpret_borrow<py::dict>(ba_closure)).collect();
         auto resObj = res.ptr();
 
         ASSERT_TRUE(PyList_Check(resObj));
@@ -1278,7 +1278,7 @@ TEST_F(WrapperTest, Airport) {
         auto pds = c.csv(sampleFile, STL_to_Python(airport_cols), false, false, ":");
 
 
-        pds = pds.mapColumn("AirportName", "lambda x: string.capwords(x) if x else None", "", py::reinterpret_steal<py::dict>(closureObject));
+        pds = pds.mapColumn("AirportName", "lambda x: string.capwords(x) if x else None", "", py::reinterpret_borrow<py::dict>(closureObject));
         pds.tocsv("airport.csv");
     }
 }
@@ -1848,7 +1848,7 @@ TEST_F(WrapperTest, BuiltinModule) {
         // import re module
         auto re_mod = PyImport_ImportModule("re");
         PyDict_SetItemString(closureObject, "re", re_mod);
-        auto v = c.parallelize(list).map("lambda x: re.search('\\\\d+', x) != None", "", py::reinterpret_steal<py::dict>(closureObject)).collect();
+        auto v = c.parallelize(list).map("lambda x: re.search('\\\\d+', x) != None", "", py::reinterpret_borrow<py::dict>(closureObject)).collect();
 
         ASSERT_EQ(PyObject_Length(v.ptr()), 3);
         auto v_str = python::PyString_AsString(v.ptr());
@@ -2051,7 +2051,7 @@ namespace tuplex {
            .filter("lambda x: x['type'] == 'house'", "")
            .withColumn("zipcode", "lambda x: '%05d' % int(x['postal_code'])", "")
            .mapColumn("city", "lambda x: x[0].upper() + x[1:].lower()", "")
-           .withColumn("bathrooms", extractBa_c, "", py::reinterpret_steal<py::dict>(ba_closure))
+           .withColumn("bathrooms", extractBa_c, "", py::reinterpret_borrow<py::dict>(ba_closure))
            .withColumn("sqft", extractSqft_c, "")
            .withColumn("offer", extractOffer_c, "")
            .withColumn("price", extractPrice_c, "")
@@ -2082,7 +2082,7 @@ namespace tuplex {
                 .withColumn("zipcode", "lambda x: '%05d' % int(x['postal_code'])", "")
                 .ignore(ecToI64(ExceptionCode::TYPEERROR))
                 .mapColumn("city", "lambda x: x[0].upper() + x[1:].lower()", "")
-                .withColumn("bathrooms", extractBa_c, "", py::reinterpret_steal<py::dict>(ba_closure))
+                .withColumn("bathrooms", extractBa_c, "", py::reinterpret_borrow<py::dict>(ba_closure))
                 .ignore(ecToI64(ExceptionCode::VALUEERROR))
                 .withColumn("sqft", extractSqft_c, "")
                 .ignore(ecToI64(ExceptionCode::VALUEERROR)) // why is this showing a single error???
@@ -2433,7 +2433,7 @@ TEST_F(WrapperTest, SingleCharCSVField) {
         // read from file incl. type hints
         auto ds = ctx.csv("testdata.part0.csv",py::none(), true, false, "", "\"",
                           py::none(),
-                          py::reinterpret_steal<py::dict>(typehints));
+                          py::reinterpret_borrow<py::dict>(typehints));
     }
 }
 
@@ -2471,7 +2471,7 @@ TEST_F(WrapperTest, NYC311) {
         // type hints:
         // vector<string>{"Unspecified", "NO CLUE", "NA", "N/A", "0", ""}
         ctx.csv(service_path,py::none(), true, false, "", "\"",
-                py::none(), py::reinterpret_steal<py::dict>(type_dict))
+                py::none(), py::reinterpret_borrow<py::dict>(type_dict))
                 .mapColumn("Incident Zip", fix_zip_codes_c, "")
                 .selectColumns(py::reinterpret_borrow<py::list>(cols_to_select))
                 .unique().show();
@@ -2615,9 +2615,9 @@ TEST_F(WrapperTest, PartitionRelease) {
         // type hints:
         // vector<string>{"Unspecified", "NO CLUE", "NA", "N/A", "0", ""}
         ctx->csv(service_path,py::none(), true, false, "", "\"",
-                py::none(), py::reinterpret_steal<py::dict>(type_dict))
+                py::none(), py::reinterpret_borrow<py::dict>(type_dict))
                 .mapColumn("Incident Zip", fix_zip_codes_c, "")
-                .selectColumns(py::reinterpret_steal<py::dict>(cols_to_select))
+                .selectColumns(py::reinterpret_borrow<py::dict>(cols_to_select))
                 .unique().show();
 
         std::cout<<std::endl;
@@ -2632,9 +2632,9 @@ TEST_F(WrapperTest, PartitionRelease) {
         PyList_SET_ITEM(cols_to_select, 0, python::PyString_FromString("Incident Zip"));
 
         ctx2.csv(service_path,py::none(), true, false, "", "\"",
-                 py::none(), py::reinterpret_steal<py::dict>(type_dict))
+                 py::none(), py::reinterpret_borrow<py::dict>(type_dict))
                 .mapColumn("Incident Zip", fix_zip_codes_c, "")
-                .selectColumns(py::reinterpret_steal<py::dict>(cols_to_select))
+                .selectColumns(py::reinterpret_borrow<py::dict>(cols_to_select))
                 .unique().show();
     }
 

--- a/tuplex/test/wrappers/WrapperTest.cc
+++ b/tuplex/test/wrappers/WrapperTest.cc
@@ -216,7 +216,7 @@ TEST_F(WrapperTest, MixedSimpleTupleTuple) {
     PyTuple_SET_ITEM(tupleObj3, 1, PyLong_FromLong(3));
 
     PyObject *tupleObj4 = PyTuple_New(2);
-    PyTuple_SET_ITEM(tupleObj4, 0, Py_RETURN_NONE);
+    PyTuple_SET_ITEM(tupleObj4, 0, python::none());
     PyTuple_SET_ITEM(tupleObj4, 1, PyLong_FromLong(4));
 
     PyList_SetItem(listObj, 0, tupleObj1);
@@ -309,7 +309,7 @@ TEST_F(WrapperTest, SimpleCSVParse) {
     fclose(f);
 
     PyObject * pyopt = PyDict_New();
-    PyDict_SetItemString(pyopt, "tuplex.webui.enable", Py_RETURN_FALSE);
+    PyDict_SetItemString(pyopt, "tuplex.webui.enable", python::boolean(false));
 
     // RAII, destruct python context!
     PythonContext c("c", "", microTestOptions().asJSON());
@@ -381,7 +381,7 @@ TEST_F(WrapperTest, Show) {
     fclose(f);
 
     PyObject * pyopt = PyDict_New();
-    PyDict_SetItemString(pyopt, "tuplex.webui.enable", Py_RETURN_FALSE);
+    PyDict_SetItemString(pyopt, "tuplex.webui.enable", python::boolean(false));
 
     // RAII, destruct python context!
     PythonContext c("python", "", microTestOptions().asJSON());
@@ -406,7 +406,7 @@ TEST_F(WrapperTest, GoogleTrace) {
     string sampleTraceFile = "../resources/gtrace-jobevents-sample.csv";
 
     PyObject * pyopt = PyDict_New();
-    PyDict_SetItemString(pyopt, "tuplex.webui.enable", Py_RETURN_FALSE);
+    PyDict_SetItemString(pyopt, "tuplex.webui.enable", python::boolean(false));
 
     // RAII, destruct python context!
     PythonContext c("python", "", testOptions().asJSON());
@@ -703,7 +703,7 @@ TEST_F(WrapperTest, UpcastParallelizeI) {
 
         PyList_SET_ITEM(listObj, 0, PyFloat_FromDouble(2.0));
         PyList_SET_ITEM(listObj, 1, PyFloat_FromDouble(3.0));
-        PyList_SET_ITEM(listObj, 2, Py_RETURN_TRUE); // auto upcast bool --> float
+        PyList_SET_ITEM(listObj, 2, python::boolean(true)); // auto upcast bool --> float
         PyList_SET_ITEM(listObj, 3, PyLong_FromLong(10)); // auto upcast int --> float
 
         auto list = py::reinterpret_borrow<py::list>(listObj);
@@ -734,8 +734,8 @@ TEST_F(WrapperTest, UpcastParallelizeII) {
         PyObject * listObj = PyList_New(4);
 
         PyList_SET_ITEM(listObj, 0, PyLong_FromLong(3));
-        PyList_SET_ITEM(listObj, 1, Py_RETURN_FALSE); // auto upcast bool --> int
-        PyList_SET_ITEM(listObj, 2, Py_RETURN_TRUE); // auto upcast bool --> int
+        PyList_SET_ITEM(listObj, 1, python::boolean(false)); // auto upcast bool --> int
+        PyList_SET_ITEM(listObj, 2, python::boolean(true)); // auto upcast bool --> int
         PyList_SET_ITEM(listObj, 3, PyLong_FromLong(2));
 
         auto list = py::reinterpret_borrow<py::list>(listObj);
@@ -781,7 +781,7 @@ TEST_F(WrapperTest, OptionListTest) {
         PyList_SET_ITEM(listObj4, 0, listObj1);
         PyList_SET_ITEM(listObj4, 1, listObj2);
         PyList_SET_ITEM(listObj5, 0, listObj3);
-        PyList_SET_ITEM(listObj5, 1, Py_RETURN_NONE);
+        PyList_SET_ITEM(listObj5, 1, python::none());
         PyTuple_SET_ITEM(tupleObj1, 0, listObj4);
         PyTuple_SET_ITEM(tupleObj2, 0, listObj5);
         PyList_SET_ITEM(listObj6, 0, tupleObj1);
@@ -894,8 +894,8 @@ TEST_F(WrapperTest, IntegerTuple) {
     using namespace tuplex;
 
     PyObject* pyopt = PyDict_New();
-    PyDict_SetItemString(pyopt, "tuplex.webui.enable", Py_RETURN_FALSE);
-    PyDict_SetItemString(pyopt, "tuplex.autoUpcast", Py_RETURN_TRUE);
+    PyDict_SetItemString(pyopt, "tuplex.webui.enable", python::boolean(false));
+    PyDict_SetItemString(pyopt, "tuplex.autoUpcast", python::boolean(true));
 
     // RAII, destruct python context!
     auto opts = microTestOptions();
@@ -1292,7 +1292,7 @@ TEST_F(WrapperTest, OptionParallelizeI) {
     PyList_SET_ITEM(listObj, 1, Py_None);
     PyList_SET_ITEM(listObj, 2, PyLong_FromLong(213));
     PyList_SET_ITEM(listObj, 3, PyLong_FromLong(345));
-    PyList_SET_ITEM(listObj, 4, Py_RETURN_NONE);
+    PyList_SET_ITEM(listObj, 4, python::none());
 
     // weird block syntax due to RAII problems.
     {
@@ -1305,10 +1305,10 @@ TEST_F(WrapperTest, OptionParallelizeI) {
 
         // check contents
         EXPECT_EQ(python::pythonToRow(PyList_GetItem(resObj, 0)), Row(112));
-        EXPECT_EQ(PyList_GetItem(resObj, 1), Py_RETURN_NONE);
+        EXPECT_EQ(PyList_GetItem(resObj, 1), python::none());
         EXPECT_EQ(python::pythonToRow(PyList_GetItem(resObj, 2)), Row(213));
         EXPECT_EQ(python::pythonToRow(PyList_GetItem(resObj, 3)), Row(345));
-        EXPECT_EQ(PyList_GetItem(resObj, 4), Py_RETURN_NONE);
+        EXPECT_EQ(PyList_GetItem(resObj, 4), python::none());
     }
 }
 
@@ -1332,10 +1332,10 @@ TEST_F(WrapperTest, OptionParallelizeII) {
     PyList_SET_ITEM(l3, 1, PyLong_FromLong(6));
 
     PyList_SET_ITEM(listObj, 0, l1);
-    PyList_SET_ITEM(listObj, 1, Py_RETURN_NONE);
+    PyList_SET_ITEM(listObj, 1, python::none());
     PyList_SET_ITEM(listObj, 2, l2);
     PyList_SET_ITEM(listObj, 3, l3);
-    PyList_SET_ITEM(listObj, 4, Py_RETURN_NONE);
+    PyList_SET_ITEM(listObj, 4, python::none());
 
     // weird block syntax due to RAII problems.
     {
@@ -1348,10 +1348,10 @@ TEST_F(WrapperTest, OptionParallelizeII) {
 
         // check contents
         EXPECT_EQ(python::pythonToRow(PyList_GetItem(resObj, 0)), Row(List(1, 2)));
-        EXPECT_EQ(PyList_GetItem(resObj, 1), Py_RETURN_NONE);
+        EXPECT_EQ(PyList_GetItem(resObj, 1), python::none());
         EXPECT_EQ(python::pythonToRow(PyList_GetItem(resObj, 2)), Row(List(3, 4)));
         EXPECT_EQ(python::pythonToRow(PyList_GetItem(resObj, 3)), Row(List(5, 6)));
-        EXPECT_EQ(PyList_GetItem(resObj, 4), Py_RETURN_NONE);
+        EXPECT_EQ(PyList_GetItem(resObj, 4), python::none());
     }
 }
 
@@ -1361,8 +1361,8 @@ TEST_F(WrapperTest, NoneParallelize) {
     PythonContext c("c", "", microTestOptions().asJSON());
 
     PyObject * listObj = PyList_New(2);
-    PyList_SET_ITEM(listObj, 0, Py_RETURN_NONE);
-    PyList_SET_ITEM(listObj, 1, Py_RETURN_NONE);
+    PyList_SET_ITEM(listObj, 0, python::none());
+    PyList_SET_ITEM(listObj, 1, python::none());
 
     // weird block syntax due to RAII problems.
     {
@@ -1374,8 +1374,8 @@ TEST_F(WrapperTest, NoneParallelize) {
         ASSERT_EQ(PyList_GET_SIZE(resObj), 2);
 
         // check contents
-        EXPECT_EQ(PyList_GetItem(resObj, 0), Py_RETURN_NONE);
-        EXPECT_EQ(PyList_GetItem(resObj, 1), Py_RETURN_NONE);
+        EXPECT_EQ(PyList_GetItem(resObj, 0), python::none());
+        EXPECT_EQ(PyList_GetItem(resObj, 1), python::none());
     }
 }
 
@@ -1400,10 +1400,10 @@ TEST_F(WrapperTest, EmptyMapI) {
         ASSERT_EQ(PyList_GET_SIZE(resObj), 4);
 
         // check contents
-        EXPECT_EQ(PyList_GetItem(resObj, 0), Py_RETURN_NONE);
-        EXPECT_EQ(PyList_GetItem(resObj, 1), Py_RETURN_NONE);
-        EXPECT_EQ(PyList_GetItem(resObj, 2), Py_RETURN_NONE);
-        EXPECT_EQ(PyList_GetItem(resObj, 3), Py_RETURN_NONE);
+        EXPECT_EQ(PyList_GetItem(resObj, 0), python::none());
+        EXPECT_EQ(PyList_GetItem(resObj, 1), python::none());
+        EXPECT_EQ(PyList_GetItem(resObj, 2), python::none());
+        EXPECT_EQ(PyList_GetItem(resObj, 3), python::none());
     }
 }
 
@@ -1496,8 +1496,8 @@ TEST_F(WrapperTest, EmptyOptionMapI) {
         EXPECT_EQ(PyTuple_GET_SIZE(PyList_GetItem(resObj, 0)), 0);
         EXPECT_TRUE(PyTuple_Check(PyList_GetItem(resObj, 1)));
         EXPECT_EQ(PyTuple_GET_SIZE(PyList_GetItem(resObj, 1)), 0);
-        EXPECT_EQ(PyList_GetItem(resObj, 2), Py_RETURN_NONE);
-        EXPECT_EQ(PyList_GetItem(resObj, 3), Py_RETURN_NONE);
+        EXPECT_EQ(PyList_GetItem(resObj, 2), python::none());
+        EXPECT_EQ(PyList_GetItem(resObj, 3), python::none());
     }
 }
 
@@ -1526,8 +1526,8 @@ TEST_F(WrapperTest, EmptyOptionMapII) {
         EXPECT_EQ(PyDict_Size(PyList_GetItem(resObj, 0)), 0);
         EXPECT_TRUE(PyDict_Check(PyList_GetItem(resObj, 1)));
         EXPECT_EQ(PyDict_Size(PyList_GetItem(resObj, 1)), 0);
-        EXPECT_EQ(PyList_GetItem(resObj, 2), Py_RETURN_NONE);
-        EXPECT_EQ(PyList_GetItem(resObj, 3), Py_RETURN_NONE);
+        EXPECT_EQ(PyList_GetItem(resObj, 2), python::none());
+        EXPECT_EQ(PyList_GetItem(resObj, 3), python::none());
     }
 }
 
@@ -1543,12 +1543,12 @@ TEST_F(WrapperTest, OptionTupleParallelizeI) {
     PyTuple_SET_ITEM(t1, 1, PyLong_FromLong(12));
 
     PyObject * t2 = PyTuple_New(2);
-    PyTuple_SET_ITEM(t2, 0, Py_RETURN_NONE);
+    PyTuple_SET_ITEM(t2, 0, python::none());
     PyTuple_SET_ITEM(t2, 1, PyLong_FromLong(100));
 
     PyObject * t3 = PyTuple_New(2);
     PyTuple_SET_ITEM(t3, 0, PyLong_FromLong(200));
-    PyTuple_SET_ITEM(t3, 1, Py_RETURN_NONE);
+    PyTuple_SET_ITEM(t3, 1, python::none());
 
     PyList_SET_ITEM(listObj, 0, t1);
     PyList_SET_ITEM(listObj, 1, t2);
@@ -1573,10 +1573,10 @@ TEST_F(WrapperTest, OptionTupleParallelizeI) {
 
         EXPECT_EQ(python::pythonToRow(PyTuple_GetItem(el1, 0)), Row(11));
         EXPECT_EQ(python::pythonToRow(PyTuple_GetItem(el1, 1)), Row(12));
-        EXPECT_EQ(PyTuple_GetItem(el2, 0), Py_RETURN_NONE);
+        EXPECT_EQ(PyTuple_GetItem(el2, 0), python::none());
         EXPECT_EQ(python::pythonToRow(PyTuple_GetItem(el2, 1)), Row(100));
         EXPECT_EQ(python::pythonToRow(PyTuple_GetItem(el3, 0)), Row(200));
-        EXPECT_EQ(PyTuple_GetItem(el3, 1), Py_RETURN_NONE);
+        EXPECT_EQ(PyTuple_GetItem(el3, 1), python::none());
     }
 }
 
@@ -2488,10 +2488,10 @@ TEST_F(WrapperTest, MixedTypesIsWithNone) {
     PythonContext c("python", "",  opts.asJSON());
 
     PyObject *listObj = PyList_New(8);
-    PyList_SetItem(listObj, 0, Py_RETURN_NONE);
+    PyList_SetItem(listObj, 0, python::none());
     PyList_SetItem(listObj, 1, PyLong_FromLong(255));
     PyList_SetItem(listObj, 2, PyLong_FromLong(400));
-    PyList_SetItem(listObj, 3, Py_RETURN_TRUE);
+    PyList_SetItem(listObj, 3, python::boolean(true));
     PyList_SetItem(listObj, 4, PyFloat_FromDouble(2.7));
     PyList_SetItem(listObj, 5, PyTuple_New(0)); // empty tuple
     PyList_SetItem(listObj, 6, PyList_New(0)); // empty list

--- a/tuplex/utils/include/Utils.h
+++ b/tuplex/utils/include/Utils.h
@@ -75,7 +75,8 @@ constexpr const char* base_file_name(const char* path) {
 
 // generates a QNAN
 // note: not used for direct comparison in isnan, as there are other representations of NAN (e.g. SNAN)
-constexpr double D_NAN = nan("");
+// cf. https://en.cppreference.com/w/cpp/types/numeric_limits/quiet_NaN
+constexpr double DOUBLE_QUIET_NAN = std::numeric_limits<double>::quiet_NaN();
 
 // macros to print out filename + line
 #define FLINESTR (std::string(base_file_name(__FILE__)) + "+" + std::to_string(__LINE__))


### PR DESCRIPTION
Bug: The math.isnan/isinf/isclose branch causes a clang error b.c. nan("") is not a constrexpr.

Solution: Replace nan("") with proper constants from https://en.cppreference.com/w/cpp/types/numeric_limits/quiet_NaN