### PR TITLE
[DOC] Update version to 0.3.7

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04, macos-11 ]
+        os: [ ubuntu-20.04, macos-12 ]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         include:
           - os: ubuntu-20.04

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -8,7 +8,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        # macos-14 (which is macos-latest) is ARM only. macos-13 is latest intel runner.
+        os: [ ubuntu-latest, macos-13 ]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         include:
           - os: ubuntu-latest
@@ -23,16 +24,16 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.11"
             cibw-build: "cp311-manylinux_x86_64"
-          - os: macos-latest
+          - os: macos-13
             python-version: "3.8"
             cibw-build: "cp38-macosx_x86_64"
-          - os: macos-latest
+          - os: macos-13
             python-version: "3.9"
             cibw-build: "cp39-macosx_x86_64"
-          - os: macos-latest
+          - os: macos-13
             python-version: "3.10"
             cibw-build: "cp310-macosx_x86_64"
-          - os: macos-latest
+          - os: macos-13
             python-version: "3.11"
             cibw-build: "cp311-macosx_x86_64"
     steps:
@@ -52,7 +53,7 @@ jobs:
             /usr/local/Frameworks
             /usr/local/bin
             /usr/local/opt
-          key: macos-latest-build-cache-${{ hashFiles('./scripts/macos/brew_dependencies.sh') }}-v2
+          key: macos-13-build-cache-${{ hashFiles('./scripts/macos/brew_dependencies.sh') }}-v2
 
       - name: Setup python
         uses: actions/setup-python@v5

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -54,8 +54,16 @@ jobs:
             /usr/local/opt
           key: macos-12-build-cache-${{ hashFiles('./scripts/macos/brew_dependencies.sh') }}-v2
 
-      - name: Build wheel
-        uses: pypa/cibuildwheel@fff9ec32ed25a9c576750c91e06b410ed0c15db7 # hash corresponds to v2.16.2
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11' 
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.22.0
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
         env:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones
@@ -66,7 +74,9 @@ jobs:
           # macOS dependencies separate, for Linux use docker tuplex/ci:3.x images.
           CIBW_BEFORE_ALL_MACOS: bash ./scripts/macos/install_antlr4_cpp_runtime.sh && bash ./scripts/macos/brew_dependencies.sh && bash ./scripts/macos/install_aws-sdk-cpp.sh && echo 'export PATH="/usr/local/opt/openjdk@11/bin:$PATH"' >> /Users/runner/.bash_profile
 
-          CIBW_ENVIRONMENT_LINUX: "CMAKE_ARGS='-DBUILD_WITH_AWS=ON -DBUILD_WITH_ORC=ON' LD_LIBRARY_PATH=/usr/local/lib:/opt/lib"
+          # If CI complains about missing /usr/local/libexec/git-core/git-remote-https: error while loading shared libraries: libssl.so.3: cannot open shared object file: No such file or directory
+          # the OpenSSL3 lib is stored under /usr/local/lib64.
+          CIBW_ENVIRONMENT_LINUX: "CMAKE_ARGS='-DBUILD_WITH_AWS=ON -DBUILD_WITH_ORC=ON' LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64:/opt/lib"
 
           # requires macOS 10.13 at least to build because of C++17 features.
           CIBW_ENVIRONMENT_MACOS: "CMAKE_ARGS='-DBUILD_WITH_AWS=ON -DBUILD_WITH_ORC=ON' JAVA_HOME=${JAVA_HOME_11_X64}"

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -90,7 +90,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}-${{ matrix.cibw_archs }}
+          name: wheels-${{ matrix.os }}-${{ matrix.cibw-build }}
           path: |
             ./wheelhouse/*.whl
 

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -23,16 +23,16 @@ jobs:
           - os: ubuntu-20.04
             python-version: "3.11"
             cibw-build: "cp311-manylinux_x86_64"
-          - os: macos-11
+          - os: macos-12
             python-version: "3.8"
             cibw-build: "cp38-macosx_x86_64"
-          - os: macos-11
+          - os: macos-12
             python-version: "3.9"
             cibw-build: "cp39-macosx_x86_64"
-          - os: macos-11
+          - os: macos-12
             python-version: "3.10"
             cibw-build: "cp310-macosx_x86_64"
-          - os: macos-11
+          - os: macos-12
             python-version: "3.11"
             cibw-build: "cp311-macosx_x86_64"
     steps:
@@ -52,7 +52,7 @@ jobs:
             /usr/local/Frameworks
             /usr/local/bin
             /usr/local/opt
-          key: macos-11-build-cache-${{ hashFiles('./scripts/macos/brew_dependencies.sh') }}-v2
+          key: macos-12-build-cache-${{ hashFiles('./scripts/macos/brew_dependencies.sh') }}-v2
 
       # need to make this an intermediate step, i.e. build first the different lambda runners on Ubuntu...
       - name: Build Lambda runner (Linux only)

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04, macos-12 ]
+        os: [ ubuntu-latest, macos-latest ]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         include:
           - os: ubuntu-20.04

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -54,16 +54,8 @@ jobs:
             /usr/local/opt
           key: macos-12-build-cache-${{ hashFiles('./scripts/macos/brew_dependencies.sh') }}-v2
 
-      - name: Setup python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11' 
-
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.22.0
-
-      - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
+      - name: Build wheel
+        uses: pypa/cibuildwheel@fff9ec32ed25a9c576750c91e06b410ed0c15db7 # hash corresponds to v2.16.2
         env:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -54,8 +54,16 @@ jobs:
             /usr/local/opt
           key: macos-12-build-cache-${{ hashFiles('./scripts/macos/brew_dependencies.sh') }}-v2
 
-      - name: Build wheel
-        uses: pypa/cibuildwheel
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11' 
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.22.0
+        
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
         env:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -90,5 +90,13 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: wheels-${{ matrix.os }}-${{ matrix.cibw_archs }}
           path: |
             ./wheelhouse/*.whl
+
+# Note: when using download-artifact, use
+#       - uses: actions/download-artifact@v4
+#         with:
+#           path: dist
+#           merge-multiple: true
+#        # Requires 4.1

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -54,15 +54,8 @@ jobs:
             /usr/local/opt
           key: macos-12-build-cache-${{ hashFiles('./scripts/macos/brew_dependencies.sh') }}-v2
 
-      # need to make this an intermediate step, i.e. build first the different lambda runners on Ubuntu...
-      - name: Build Lambda runner (Linux only)
-        if: runner.os != 'macOS'
-        run: docker pull registry-1.docker.io/tuplex/ci:${{ matrix.python-version }} && export PYTHON3_VERSION=${{ matrix.python-version }}.0 && bash ./scripts/create_lambda_zip.sh && mkdir -p ./tuplex/python/tuplex/other && cp ./build-lambda/tplxlam.zip ./tuplex/python/tuplex/other
-        shell: bash
-
       - name: Build wheel
-        #if: runner.os != 'macOS'
-        uses: pypa/cibuildwheel@fff9ec32ed25a9c576750c91e06b410ed0c15db7 # hash corresponds to v2.16.2
+        uses: pypa/cibuildwheel
         env:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones
@@ -70,11 +63,10 @@ jobs:
           CIBW_MANYLINUX_X86_64_IMAGE: "registry-1.docker.io/tuplex/ci:${{ matrix.python-version }}"
           CIBW_BUILD: ${{ matrix.cibw-build }}
 
-          # macOS dependencies separate, for linux use docker tuplex/ci:3.x images.
+          # macOS dependencies separate, for Linux use docker tuplex/ci:3.x images.
           CIBW_BEFORE_ALL_MACOS: bash ./scripts/macos/install_antlr4_cpp_runtime.sh && bash ./scripts/macos/brew_dependencies.sh && bash ./scripts/macos/install_aws-sdk-cpp.sh && echo 'export PATH="/usr/local/opt/openjdk@11/bin:$PATH"' >> /Users/runner/.bash_profile
 
-          # bundle aws runner with linux wheel, remove environment variable TUPLEX_LAMBDA_ZIP to remove runner.
-          CIBW_ENVIRONMENT_LINUX: "TUPLEX_LAMBDA_ZIP='./tuplex/python/tuplex/other/tplxlam.zip' CMAKE_ARGS='-DBUILD_WITH_AWS=ON -DBUILD_WITH_ORC=ON' LD_LIBRARY_PATH=/usr/local/lib:/opt/lib"
+          CIBW_ENVIRONMENT_LINUX: CMAKE_ARGS='-DBUILD_WITH_AWS=ON -DBUILD_WITH_ORC=ON' LD_LIBRARY_PATH=/usr/local/lib:/opt/lib"
 
           # requires macOS 10.13 at least to build because of C++17 features.
           CIBW_ENVIRONMENT_MACOS: "CMAKE_ARGS='-DBUILD_WITH_AWS=ON -DBUILD_WITH_ORC=ON' JAVA_HOME=${JAVA_HOME_11_X64}"

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -36,11 +36,11 @@ jobs:
             python-version: "3.11"
             cibw-build: "cp311-macosx_x86_64"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Cache brew dependencies
         if: runner.os == 'macOS'
-        uses: actions/cache@v3.3.2
+        uses: actions/cache@v4.2.1
         with:
           # Paths to cache:
           # /usr/local/Homebrew - installation folder of Homebrew
@@ -86,7 +86,7 @@ jobs:
       - name: reorganize files
         run: touch ./scripts/dummy.version && cp ./scripts/*.version ./wheelhouse && cp ./.github/scripts/test_pypi.sh ./wheelhouse
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: |
             ./wheelhouse/*.whl

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -89,8 +89,13 @@ jobs:
 
           # run all python tests to make sure wheels are not defunct
           CIBW_TEST_REQUIRES: "pytest pytest-timeout numpy nbformat jupyter"
+
+          # Use following test command when segfaults happen to better pinpoint:
+          # python3 -X faulthandler -m pytest -p no:faulthandler
+          # else can use pytest ...
+
           # use 3min timeout per test and print top 25 slowest tests
-          CIBW_TEST_COMMAND: "cd {project} && pytest tuplex/python/tests -v --timeout 600 --durations 25"
+          CIBW_TEST_COMMAND: "cd {project} && python3 -X faulthandler -m pytest -p no:faulthandler tuplex/python/tests -v --timeout 600 --durations 25"
 
       - name: reorganize files
         run: touch ./scripts/dummy.version && cp ./scripts/*.version ./wheelhouse && cp ./.github/scripts/test_pypi.sh ./wheelhouse

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.22.0
-        
+
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
@@ -74,7 +74,7 @@ jobs:
           # macOS dependencies separate, for Linux use docker tuplex/ci:3.x images.
           CIBW_BEFORE_ALL_MACOS: bash ./scripts/macos/install_antlr4_cpp_runtime.sh && bash ./scripts/macos/brew_dependencies.sh && bash ./scripts/macos/install_aws-sdk-cpp.sh && echo 'export PATH="/usr/local/opt/openjdk@11/bin:$PATH"' >> /Users/runner/.bash_profile
 
-          CIBW_ENVIRONMENT_LINUX: CMAKE_ARGS='-DBUILD_WITH_AWS=ON -DBUILD_WITH_ORC=ON' LD_LIBRARY_PATH=/usr/local/lib:/opt/lib"
+          CIBW_ENVIRONMENT_LINUX: "CMAKE_ARGS='-DBUILD_WITH_AWS=ON -DBUILD_WITH_ORC=ON' LD_LIBRARY_PATH=/usr/local/lib:/opt/lib"
 
           # requires macOS 10.13 at least to build because of C++17 features.
           CIBW_ENVIRONMENT_MACOS: "CMAKE_ARGS='-DBUILD_WITH_AWS=ON -DBUILD_WITH_ORC=ON' JAVA_HOME=${JAVA_HOME_11_X64}"

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -11,28 +11,28 @@ jobs:
         os: [ ubuntu-latest, macos-latest ]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             python-version: "3.8"
             cibw-build: "cp38-manylinux_x86_64"
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             python-version: "3.9"
             cibw-build: "cp39-manylinux_x86_64"
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             python-version: "3.10"
             cibw-build: "cp310-manylinux_x86_64"
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             python-version: "3.11"
             cibw-build: "cp311-manylinux_x86_64"
-          - os: macos-12
+          - os: macos-latest
             python-version: "3.8"
             cibw-build: "cp38-macosx_x86_64"
-          - os: macos-12
+          - os: macos-latest
             python-version: "3.9"
             cibw-build: "cp39-macosx_x86_64"
-          - os: macos-12
+          - os: macos-latest
             python-version: "3.10"
             cibw-build: "cp310-macosx_x86_64"
-          - os: macos-12
+          - os: macos-latest
             python-version: "3.11"
             cibw-build: "cp311-macosx_x86_64"
     steps:
@@ -52,7 +52,7 @@ jobs:
             /usr/local/Frameworks
             /usr/local/bin
             /usr/local/opt
-          key: macos-12-build-cache-${{ hashFiles('./scripts/macos/brew_dependencies.sh') }}-v2
+          key: macos-latest-build-cache-${{ hashFiles('./scripts/macos/brew_dependencies.sh') }}-v2
 
       - name: Setup python
         uses: actions/setup-python@v5

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -2,6 +2,10 @@ name: Build
 
 on: [push, pull_request, workflow_dispatch]
 
+env:
+  # At least 10.13 is required, to avoid issues and since the runner is macos-13 -> use 13.0, which is Venture from 2022.
+  MACOSX_DEPLOYMENT_TARGET: 13.0
+
 jobs:
   build_wheels:
     name: Build wheel on ${{ matrix.os }} - py ${{ matrix.python-version }}
@@ -79,8 +83,10 @@ jobs:
           # the OpenSSL3 lib is stored under /usr/local/lib64.
           CIBW_ENVIRONMENT_LINUX: "CMAKE_ARGS='-DBUILD_WITH_AWS=ON -DBUILD_WITH_ORC=ON' LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64:/opt/lib"
 
-          # requires macOS 10.13 at least to build because of C++17 features.
-          CIBW_ENVIRONMENT_MACOS: "CMAKE_ARGS='-DBUILD_WITH_AWS=ON -DBUILD_WITH_ORC=ON' JAVA_HOME=${JAVA_HOME_11_X64}"
+          # Requires macOS 10.13 at least to build because of C++17 features.
+          # To avoid issues, simply use 13.0 for now.
+          CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} CMAKE_ARGS='-DBUILD_WITH_AWS=ON -DBUILD_WITH_ORC=ON' JAVA_HOME=${JAVA_HOME_11_X64}"
+
           # run all python tests to make sure wheels are not defunct
           CIBW_TEST_REQUIRES: "pytest pytest-timeout numpy nbformat jupyter"
           # use 3min timeout per test and print top 25 slowest tests

--- a/README.md
+++ b/README.md
@@ -133,4 +133,4 @@ series = {SIGMOD/PODS '21}
 ```
 
 ---
-(c) 2017-2024 Tuplex contributors
+(c) 2017-2025 Tuplex contributors

--- a/README.md
+++ b/README.md
@@ -133,4 +133,4 @@ series = {SIGMOD/PODS '21}
 ```
 
 ---
-(c) 2017-2023 Tuplex contributors
+(c) 2017-2024 Tuplex contributors

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ jobs:
         displayName: 'Install MongoDB'
       - script: sudo bash scripts/azure/install_azure_ci_reqs.sh
         displayName: 'Install required packages'
-      - script: sudo apt-get install -y python3-setuptools ninja-build && python3 -m pip install pytest pygments>=2.4.1 MarkupSafe==2.0 pexpect setuptools astor PyYAML jupyter nbformat pymongo eventlet==0.30.0 gunicorn pymongo && jupyter --version
+      - script: sudo apt-get install -y python3-setuptools ninja-build && python3 -m pip install pytest pygments>=2.4.1 MarkupSafe==2.0 pexpect setuptools astor PyYAML jupyter nbformat pymongo eventlet==0.30.0 gunicorn pymongo "lxml[html_clean]" && jupyter --version
         displayName: 'Install python dependencies'
       - script: cd tuplex/python && python3 -m pip install -r requirements.txt && python3 mongodb_test.py && pkill mongod || true
         displayName: 'Test local MongoDB'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,5 +30,5 @@ jobs:
         displayName: 'Build Tuplex'
       - script: cd build/temp.linux-x86_64-3.10 && ctest --timeout 180 --output-on-failure --repeat until-pass:3 -j 2
         displayName: 'C++ tests'
-      - script: cd build/temp.linux-x86_64-3.10/dist/python && python3.10 -m pytest -x --full-trace -l --log-cli-level=DEBUG --capture=tee-sys
+      - script: cd build/temp.linux-x86_64-3.10/dist/python && python3.10 -m pip install lxml_html_clean && python3.10 -m pytest -x --full-trace -l --log-cli-level=DEBUG --capture=tee-sys
         displayName: 'Python tests'

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -36,7 +36,7 @@ author = 'Leonhard Spiegelberg'
 # The short X.Y version
 version="0.3"
 # The full version, including alpha/beta/rc tags
-release="0.3.6"
+release="0.3.7"
 
 
 # -- General configuration ---------------------------------------------------

--- a/scripts/azure/install_azure_ci_reqs.sh
+++ b/scripts/azure/install_azure_ci_reqs.sh
@@ -86,7 +86,7 @@ mkdir -p /root/.ssh/ &&
 mkdir -p ${WORKDIR}/boost
 
 # build incl. boost python
-pushd ${WORKDIR}/boost && wget https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.gz && tar xf boost_1_79_0.tar.gz && cd ${WORKDIR}/boost/boost_1_79_0 \
+pushd ${WORKDIR}/boost && wget https://github.com/boostorg/boost/releases/download/boost-1.87.0/boost-1.87.0-b2-nodocs.tar.gz && tar xf boost-1.87.0-b2-nodocs.tar.gz && cd ${WORKDIR}/boost/boost-1.87.0 \
            && ./bootstrap.sh --with-python=${PYTHON_EXECUTABLE} --prefix=${PREFIX} --with-libraries="thread,iostreams,regex,system,filesystem,python,stacktrace,atomic,chrono,date_time" \
             && ./b2 cxxflags="-fPIC" link=static -j "$(nproc)" \
             && ./b2 cxxflags="-fPIC" link=static install && sed -i 's/#if PTHREAD_STACK_MIN > 0/#ifdef PTHREAD_STACK_MIN/g' ${PREFIX}/include/boost/thread/pthread/thread_data.hpp

--- a/scripts/azure/install_azure_ci_reqs.sh
+++ b/scripts/azure/install_azure_ci_reqs.sh
@@ -138,5 +138,5 @@ mkdir -p ${WORKDIR}/pcre2 && cd ${WORKDIR}/pcre2 \
 && ./configure CFLAGS="-O2 -fPIC" --prefix=${PREFIX} --enable-jit=auto --disable-shared \
 && make -j$(nproc) && make install
 mkdir -p ${WORKDIR}/protobuf && cd ${WORKDIR}/protobuf && git clone -b v24.3 https://github.com/protocolbuffers/protobuf.git && cd protobuf && git submodule update --init --recursive && mkdir build && cd build && cmake -DCMAKE_CXX_FLAGS="-fPIC" -DCMAKE_CXX_STANDARD=17 -Dprotobuf_BUILD_TESTS=OFF .. && make -j$(nproc) && make install && ldconfig
-pip3 install 'cloudpickle>2.0.0' cython numpy
+pip3 install 'cloudpickle>2.0.0' cython numpy 'lxml[html_clean]'
 echo ">>> installing reqs done."

--- a/scripts/build_macos_3.11_wheel_with_test.sh
+++ b/scripts/build_macos_3.11_wheel_with_test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# (c) 2017-2023 Tuplex team
+# builds x86_64 (and arm64) wheels
+
+# add -x option for verbose output
+set -euo pipefail
+
+function fail {
+    printf '%s\n' "$1" >&2
+    exit "${2-1}"
+}
+
+function detect_instruction_set() {
+  arch="$(uname -m)"  # -i is only linux, -m is linux and apple
+  if [[ "$arch" = x86_64* ]]; then
+    if [[ "$(uname -a)" = *ARM64* ]]; then
+      echo 'arm64'
+    else
+      echo 'x86_64'
+    fi
+  elif [[ "$arch" = i*86 ]]; then
+    echo 'x86_32'
+  elif [[ "$arch" = arm* ]]; then
+    echo $arch
+  elif test "$arch" = aarch64; then
+    echo 'arm64'
+  else
+    exit 1
+	fi
+}
+
+# check from where script is invoked
+CWD="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+echo " || Tuplex macOS wheel builder || "
+echo "-- Executing buildwheel script located in $CWD"
+
+# check platform is darwin
+if [ ! "$(uname -s)" = "Darwin" ]; then
+  fail "Error: Need to run script under macOS"
+fi
+
+# check which tags are supported
+arch=$(detect_instruction_set)
+echo "-- Detected arch ${arch}"
+
+# try to extract version of compiler first via command-line tools or xcode
+# either needs to be installed.
+xcode_version_str=$(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables 2>/dev/null | grep version || pkgutil --pkg-info=com.apple.pkg.Xcode | grep version)
+echo "-- Detected Xcode ${xcode_version_str}"
+
+# if no param is given, use defaults to build all
+if [ "${arch}" = "arm64" ]; then
+  # build Python 3.9 - 3.11
+  CIBW_BUILD=${CIBW_BUILD-"cp311-macosx_arm64"}
+else
+  # build Python 3.8 - 3.11
+  CIBW_BUILD=${CIBW_BUILD-"cp311-macosx_x86_64"}
+fi
+
+echo "-- Building wheels for ${CIBW_BUILD}"
+
+MACOS_VERSION=$(sw_vers -productVersion)
+echo "-- Processing on MacOS ${MACOS_VERSION}"
+function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
+
+MACOS_VERSION_MAJOR=`echo $MACOS_VERSION | cut -d . -f1`
+
+if [ "$MACOS_VERSION_MAJOR" -ge 11 ]; then
+    echo "-- Newer MacOS detected (>=11.0), using more recent base target."
+    echo "-- Using minimum target ${MACOS_VERSION_MAJOR}.0"
+    MINIMUM_TARGET="${MACOS_VERSION_MAJOR}.0"
+else
+    # keep as is
+    echo "-- Defaulting build to use as minimum target ${MINIMUM_TARGET}"
+fi
+
+pushd $CWD > /dev/null
+cd ..
+
+# Use 13.0
+MINIMUM_TARGET=13.0
+export MACOSX_DEPLOYMENT_TARGET=${MINIMUM_TARGET}
+
+# Note: protobuf 3.20 - 3.21.2 is broken for MacOS, do not use those versions
+export CIBW_BEFORE_BUILD_MACOS="brew install protobuf coreutils zstd zlib libmagic llvm@16 aws-sdk-cpp pcre2 antlr4-cpp-runtime googletest gflags yaml-cpp celero wget boost ninja snappy libdwarf libelf"
+
+
+# Note: orc build breaks wheel right now...
+export CIBW_ENVIRONMENT_MACOS="MACOSX_DEPLOYMENT_TARGET=${MINIMUM_TARGET} CMAKE_ARGS='-DBUILD_WITH_AWS=ON -DBUILD_WITH_ORC=ON' TUPLEX_BUILD_TYPE=RelWithDebInfo"
+#export CIBW_ENVIRONMENT_MACOS="MACOSX_DEPLOYMENT_TARGET=${MINIMUM_TARGET} CMAKE_ARGS='-DBUILD_WITH_AWS=ON -DBUILD_WITH_ORC=ON' TUPLEX_BUILD_TYPE=Debug"
+
+export CIBW_BUILD="${CIBW_BUILD}"
+export CIBW_PROJECT_REQUIRES_PYTHON=">=3.8"
+
+# uncomment to increase verbosity of cibuildwheel
+export CIBW_BUILD_VERBOSITY=3
+
+# uncomment and set to specific identifier
+#export CIBW_BUILD="cp39-macosx_x86_64"
+
+export CIBW_TEST_REQUIRES="pytest pytest-timeout numpy nbformat jupyter"
+export CIBW_TEST_COMMAND="cd {project} && python3 -X faulthandler -m pytest -p no:faulthandler tuplex/python/tests --timeout_method thread --timeout 300 -l -v"
+
+cibuildwheel --platform macos
+
+popd

--- a/scripts/macos/install_antlr4_cpp_runtime.sh
+++ b/scripts/macos/install_antlr4_cpp_runtime.sh
@@ -12,6 +12,9 @@ if [ -d "${PREFIX}/include/antlr4-runtime" ]; then
   exit 0
 fi
 
+# use arm64 or x86_64.
+ARCH=x86_64
+
 # if macOS is 10.x -> use this as minimum
 MINIMUM_TARGET="-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13"
 
@@ -35,6 +38,7 @@ git clone https://github.com/antlr/antlr4.git \
 && cd antlr4 && cd runtime &&  git fetch --all --tags \
 && git checkout tags/4.13.1 -b 4.13.1 && cd Cpp/ \
 && sed -i '' "s/cmake ./cmake . ${MINIMUM_TARGET}/g" deploy-macos.sh \
+&& sed -i '' "s/CMAKE_OSX_ARCHITECTURES=\"arm64; x86_64\"/CMAKE_OSX_ARCHITECTURES=\"${ARCH}\"/g" deploy-macos.sh \
 && cat deploy-macos.sh \
 && ./deploy-macos.sh \
 && unzip -l antlr4-cpp-runtime-macos.zip && unzip antlr4-cpp-runtime-macos.zip \

--- a/scripts/set_version.py
+++ b/scripts/set_version.py
@@ -15,9 +15,8 @@ def LooseVersion(v):
     parts = v.split('.')
     return parts
 
-
-# to create a testpypi version use X.Y.devN
-version = '0.3.6'
+# change here and run script within its directory to update versions across the board
+version = '0.3.7'
 
 # https://pypi.org/simple/tuplex/
 # or https://test.pypi.org/simple/tuplex/

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ test_dependencies = [
 
 # Also requires to install MongoDB
 webui_dependencies = [
-    'Flask>=2.0.2',
+    'Flask>=3.0',
     'Werkzeug',
     'gunicorn',
     'eventlet==0.30.0', # newer versions of eventlet have a bug under MacOS

--- a/setup.py
+++ b/setup.py
@@ -695,7 +695,7 @@ def tplx_package_data():
 # logic and declaration, and simpler if you include description/version in a file.
 setup(name="tuplex",
     python_requires='>=3.8.0',
-    version="0.3.6",
+    version="0.3.7",
     author="Leonhard Spiegelberg",
     author_email="tuplex@cs.brown.edu",
     description="Tuplex is a novel big data analytics framework incorporating a Python UDF compiler based on LLVM "

--- a/setup.py
+++ b/setup.py
@@ -70,8 +70,8 @@ test_dependencies = [
 
 # Also requires to install MongoDB
 webui_dependencies = [
-    'Flask>=2.0.2,<2.2.0',
-    'Werkzeug<2.2.0',
+    'Flask>=2.0.2',
+    'Werkzeug',
     'gunicorn',
     'eventlet==0.30.0', # newer versions of eventlet have a bug under MacOS
     'flask-socketio',
@@ -117,8 +117,8 @@ if in_google_colab():
     logging.debug('Building dependencies for Google Colab environment')
 
     install_dependencies = [
-        'urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1',
-        'folium==0.2.1'
+        'urllib3!=1.25.0,!=1.25.1,>=1.21.1',
+        'folium>=0.2.1'
         'requests',
         'attrs>=19.2.0',
         'dill>=0.2.7.1',

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ test_dependencies = [
 'nbformat<7.0',
 'prompt_toolkit>=2.0.7',
 'pytest>=5.3.2'
+'lxml[html_clean]'
 ]
 
 # Also requires to install MongoDB

--- a/tuplex/cmake/FindLibDwarf.cmake
+++ b/tuplex/cmake/FindLibDwarf.cmake
@@ -32,8 +32,10 @@ find_path (DWARF_INCLUDE_DIR
         ${PkgConfig_LibDwarf_INCLUDE_DIRS}
         /usr/include
         /usr/include/libdwarf
+        /usr/include/libdwarf-0
         /usr/local/include
         /usr/local/include/libdwarf
+        /usr/local/include/libdwarf-0
         /opt/local/include
         /sw/include
         ENV CPATH) # PATH and INCLUDE will also work

--- a/tuplex/historyserver/requirements.txt
+++ b/tuplex/historyserver/requirements.txt
@@ -4,12 +4,12 @@ jedi
 astor==0.7.1
 pandas>=0.23.4
 cloudpickle
-Werkzeug==2.0.1
+Werkzeug>=2.0.1
 flask>=2.0.1
-flask_socketio==4.3.1
-python-socketio==4.6.0
-python-engineio==3.13.2
-flask_pymongo==2.2.0
+flask_socketio>=4.3.1
+python-socketio>=4.6.0
+python-engineio>=3.13.2
+flask_pymongo>=2.2.0
 iso8601==0.1.12
 dill==0.2.8.2
 greenlet>=0.4.15

--- a/tuplex/historyserver/thserver/version.py
+++ b/tuplex/historyserver/thserver/version.py
@@ -1,2 +1,2 @@
-# (c) L.Spiegelberg 2017 - 2023
-__version__="0.3.6"
+# (c) L.Spiegelberg 2017 - 2024
+__version__="0.3.7"

--- a/tuplex/io/CMakeLists.txt
+++ b/tuplex/io/CMakeLists.txt
@@ -38,9 +38,19 @@ if(BUILD_WITH_ORC)
                 set(SNAPPY_STATIC_LIB "${SNAPPY_HOME}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}snappy${CMAKE_STATIC_LIBRARY_SUFFIX}")
                 set(SNAPPY_CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${SNAPPY_HOME}
                         -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_LIBDIR=lib -DSNAPPY_BUILD_BENCHMARKS=OFF -DSNAPPY_BUILD_TESTS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON)
+                
+                # set(PATCH_CMD_FOR_SNAPPY git apply "${CMAKE_CURRENT_LIST_DIR}/patches/snappy.diff")
+                
+                # cf. https://gitlab.kitware.com/cmake/cmake/-/issues/17287
+                set(PATCH_CMD_FOR_SNAPPY bash -c "echo test && ls ${SNAPPY_HOME}/src && cat \"${CMAKE_CURRENT_LIST_DIR}/patches/snappy.diff\" && patch -p1 < \"${CMAKE_CURRENT_LIST_DIR}/patches/snappy.diff\"")
+
+                # this here works.
+                # set(PATCH_CMD_FOR_SNAPPY cat "${CMAKE_CURRENT_LIST_DIR}/patches/snappy.diff")
+                
                 ExternalProject_Add (snappy_ep
                         URL "https://github.com/google/snappy/archive/${SNAPPY_VERSION}.tar.gz"
                         CMAKE_ARGS ${SNAPPY_CMAKE_ARGS}
+                        PATCH_COMMAND ${PATCH_CMD_FOR_SNAPPY}
                         BUILD_BYPRODUCTS "${SNAPPY_STATIC_LIB}")
 
                 set(SNAPPY_LIBRARIES ${SNAPPY_STATIC_LIB})

--- a/tuplex/io/CMakeLists.txt
+++ b/tuplex/io/CMakeLists.txt
@@ -38,13 +38,10 @@ if(BUILD_WITH_ORC)
                 set(SNAPPY_STATIC_LIB "${SNAPPY_HOME}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}snappy${CMAKE_STATIC_LIBRARY_SUFFIX}")
                 set(SNAPPY_CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${SNAPPY_HOME}
                         -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_LIBDIR=lib -DSNAPPY_BUILD_BENCHMARKS=OFF -DSNAPPY_BUILD_TESTS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON)
-                
-                # set(PATCH_CMD_FOR_SNAPPY git apply "${CMAKE_CURRENT_LIST_DIR}/patches/snappy.diff")
-                
-                # cf. https://gitlab.kitware.com/cmake/cmake/-/issues/17287
-                set(PATCH_CMD_FOR_SNAPPY bash -c "echo test && ls ${SNAPPY_HOME}/src && cat \"${CMAKE_CURRENT_LIST_DIR}/patches/snappy.diff\" && patch -p1 < \"${CMAKE_CURRENT_LIST_DIR}/patches/snappy.diff\"")
 
-                # this here works.
+                # cf. https://gitlab.kitware.com/cmake/cmake/-/issues/17287
+                set(PATCH_CMD_FOR_SNAPPY bash -c "patch -p1 < \"${CMAKE_CURRENT_LIST_DIR}/patches/snappy.diff\"")
+                # To show what the patch looks like, use:
                 # set(PATCH_CMD_FOR_SNAPPY cat "${CMAKE_CURRENT_LIST_DIR}/patches/snappy.diff")
                 
                 ExternalProject_Add (snappy_ep

--- a/tuplex/io/patches/snappy.diff
+++ b/tuplex/io/patches/snappy.diff
@@ -1,0 +1,13 @@
+diff --git a/snappy.cc b/snappy.cc
+index d4147185..955ff303 100644
+--- a/snappy.cc
++++ b/snappy.cc
+@@ -1290,7 +1290,7 @@ std::pair<const uint8_t*, ptrdiff_t> DecompressBranchless(
+         DeferMemCopy(&deferred_src, &deferred_length, from, len);
+       }
+     } while (ip < ip_limit_min_slop &&
+-             (op + deferred_length) < op_limit_min_slop);
++             (long)(op + deferred_length) < (long)op_limit_min_slop);
+   exit:
+     ip--;
+     assert(ip <= ip_limit);

--- a/tuplex/python/CMakeLists.txt
+++ b/tuplex/python/CMakeLists.txt
@@ -18,7 +18,7 @@ message(STATUS "Pybind11 uses python version ${Python3_VERSION}")
 set(PYBIND11_FINDPYTHON OFF CACHE INTERNAL "") 
 set(PYBIND11_PYTHON_VERSION "${Python3_VERSION}" CACHE INTERNAL "")
 FetchContent_Declare(pybind11 GIT_REPOSITORY https://github.com/pybind/pybind11
-                             GIT_TAG        v2.11.1 )
+                             GIT_TAG        v2.13.6)
 FetchContent_GetProperties(pybind11)
 if(NOT pybind11_POPULATED)
     FetchContent_Populate(pybind11)

--- a/tuplex/python/requirements.txt
+++ b/tuplex/python/requirements.txt
@@ -1,6 +1,7 @@
 nbconvert<7.0
 jupyter<7.0
 nbformat<7.0
+lxml[html_clean]
 Werkzeug
 attrs>=19.2.0
 dill>=0.2.7.1

--- a/tuplex/python/requirements.txt
+++ b/tuplex/python/requirements.txt
@@ -1,7 +1,7 @@
 nbconvert<7.0
 jupyter<7.0
 nbformat<7.0
-Werkzeug<2.2.0
+Werkzeug
 attrs>=19.2.0
 dill>=0.2.7.1
 pluggy>=0.6.0, <1.0.0

--- a/tuplex/python/setup.py
+++ b/tuplex/python/setup.py
@@ -45,7 +45,7 @@ setup(
         'nbconvert<7.0',
         'jupyter<7.0',
         'nbformat<7.0',
-        'Werkzeug<2.2.0',
+        'Werkzeug',
         'attrs>=19.2.0',
         'dill>=0.2.7.1',
         'pluggy>=0.6.0, <1.0.0',

--- a/tuplex/python/setup.py
+++ b/tuplex/python/setup.py
@@ -29,7 +29,7 @@ files = list(filter(lambda x: '__pycache__' not in x and not x.endswith('.pyc'),
 
 setup(
     name="Tuplex",
-    version="0.3.6",
+    version="0.3.7",
     packages=find_packages(),
     package_data={
       # include libs in libexec

--- a/tuplex/python/src/PythonDataSet.cc
+++ b/tuplex/python/src/PythonDataSet.cc
@@ -83,7 +83,9 @@ namespace tuplex {
             // new version, directly interact with the interpreter
             Timer timer;
 
-            Logger::instance().logger("python").info("Converting result-set to CPython objects");
+            auto output_row_count = rs->rowCount();
+
+            Logger::instance().logger("python").info("Converting result-set to CPython objects (" + pluralize(output_row_count, "row") + ")");
 
             // build python list object from resultset
             auto listObj = resultSetToCPython(rs.get(), std::numeric_limits<size_t>::max());
@@ -102,7 +104,7 @@ namespace tuplex {
 #endif
 
             Logger::instance().logger("python").info("Data transfer back to Python took "
-                                                     + std::to_string(timer.time()) + " seconds");
+                                                     + std::to_string(timer.time()) + " seconds (" + pluralize(PyList_Size(listObj), "element") + ")");
 
             auto list = pybind_list_from_obj(listObj);
             // Logger::instance().flushAll();

--- a/tuplex/python/tests/notebook_utils.py
+++ b/tuplex/python/tests/notebook_utils.py
@@ -47,8 +47,12 @@ def notebook_run(path):
         args = ['jupyter', "nbconvert", "--to", "notebook", "--execute",
                 "--ExecutePreprocessor.timeout=60",
                 "--output", fout.name, path]
-        subprocess.check_call(args, stderr=subprocess.DEVNULL)
-
+        try:
+            # use: subprocess.DEVNULL?
+            subprocess.check_call(args, stderr=subprocess.STDOUT, universal_newlines=True)
+        except subprocess.CalledProcessError as exc:
+            logging.error(f"FAIL notebook_run {path}:  {exc.returncode}  {exc.output}")
+            raise exc
         fout.seek(0)
         nb = nbformat.read(fout, nbformat.current_nbformat)
 

--- a/tuplex/python/tests/test_exceptions.py
+++ b/tuplex/python/tests/test_exceptions.py
@@ -100,8 +100,10 @@ class TestExceptions:
         # for larger partitions, there's a multi-threading issue for this.
         # need to fix.
         conf = self.conf_in_order
+
         # use this line to force single-threaded
-        # conf['executorCount'] = 0
+        conf['executorCount'] = 0
+
         c = Context(conf)
         output = c.parallelize(input).filter(filter_udf).map(map_udf).resolve(ZeroDivisionError, resolve_udf).collect()
 

--- a/tuplex/python/tuplex/utils/version.py
+++ b/tuplex/python/tuplex/utils/version.py
@@ -1,2 +1,2 @@
-# (c) L.Spiegelberg 2017 - 2023
-__version__="0.3.6"
+# (c) L.Spiegelberg 2017 - 2024
+__version__="0.3.7"


### PR DESCRIPTION
Update version to 0.3.7.

Other:
- Update macos runner to macos13 (last github action runner to support x86)
- Remove packaging of lambda runner in github wheel to reduce size.
- Update github artifact action to v4.
- Use more recent pybind v2.13.6.
- Add patch for snappy to avoid error on macos/cmake when building with ORC support.
- Add lxml_html_clean for jupyter/notebook testing.
- Print explicitly for collect how many elements are transferred in logger.