### PR TITLE
refactor: adding random seed in one test

### DIFF
--- a/tuplex/python/tests/test_exceptions.py
+++ b/tuplex/python/tests/test_exceptions.py
@@ -12,10 +12,11 @@
 import unittest
 import pytest
 from tuplex import Context
-from random import randint, sample, shuffle
+from random import randint, sample, shuffle, seed
 from math import floor
 from helper import options_for_pytest
 
+seed(42)
 
 class TestExceptions:
 


### PR DESCRIPTION
While reviewing the code, I noticed that the `test_exceptions.py` file uses random operations and does not have seed. This pull request updates the `test_exceptions.py` file to include the `seed` function from the random module and sets a fixed seed value `seed(42)`. This ensures reproducible random operations in the test, improving consistency and helping to prevent potential flakiness in test results in the ci.